### PR TITLE
Add find-orb as software app for arcade desktop

### DIFF
--- a/containers/session-containers/skaha-desktop/VERSION
+++ b/containers/session-containers/skaha-desktop/VERSION
@@ -1,4 +1,4 @@
 ## deployable containers have a semantic and build tag
 # semantic version tag: major.minor
 # build version tag: timestamp
-TAGS="0.4.10 $(date -u +"%Y%m%dT%H%M%S")"
+TAGS="0.4.11 $(date -u +"%Y%m%dT%H%M%S")"

--- a/containers/session-containers/skaha-desktop/skaha-software.properties
+++ b/containers/session-containers/skaha-desktop/skaha-software.properties
@@ -36,3 +36,4 @@ k-pop = images.canfar.net/k-pop/kpop-desktop:1.1
 lsst = images.canfar.net/lsst/lsst_v19_0_0:0.1
 new-horizons = images.canfar.net/uvickbos/find_moving:0.1
 tnorecon = images.canfar.net/uvickbos/sora:0.3
+find-orb = images.canfar.net/uvickbos/find-orb:0.1

--- a/k8s-config/kustomize/base/skaha/config/skaha-software.properties
+++ b/k8s-config/kustomize/base/skaha/config/skaha-software.properties
@@ -36,3 +36,4 @@ lsst = images.canfar.net/lsst/lsst_v19_0_0:0.1
 k-pop = images.canfar.net/k-pop/kpop-desktop:1.1
 new-horizons = images.canfar.net/uvickbos/find_moving:0.1
 tnorecon = images.canfar.net/uvickbos/sora:0.3
+find-orb =  images.canfar.net/uvickbos/find-orb:0.1


### PR DESCRIPTION
This is a first attempt at a 'User' following the instructions here; 

https://cadc-ccda.atlassian.net/wiki/spaces/C/pages/1453490177/Adding+new+skaha-desktop+applications

to update the arcade desktop top.  Next step is for OPS.