### PR TITLE
Improve launch speed by precompiling Pluto 

### DIFF
--- a/containers/session-containers/skaha-pluto/Dockerfile
+++ b/containers/session-containers/skaha-pluto/Dockerfile
@@ -1,26 +1,74 @@
 FROM centos:7
 
-RUN yum makecache -y
-RUN yum update -y
-RUN yum install -y iproute lsof sssd-client acl wget
+RUN yum makecache -y && \
+    yum update -y && \
+    yum install -y iproute lsof sssd-client acl wget && yum group install -y "Development Tools" && \
+    yum clean all
 
-RUN cd /
-RUN wget https://julialang-s3.julialang.org/bin/linux/x64/1.7/julia-1.7.2-linux-x86_64.tar.gz
-RUN tar zxvf julia-1.7.2-linux-x86_64.tar.gz
+WORKDIR /
+RUN wget https://julialang-s3.julialang.org/bin/linux/x64/1.7/julia-1.7.2-linux-x86_64.tar.gz && \
+    tar zxvf julia-1.7.2-linux-x86_64.tar.gz && \
+    rm julia-1.7.2-linux-x86_64.tar.gz
+
+# We want to set up Julia carefully.
+# We want some packages e.g. Pluto backed into the container,
+# and we want others to persist in the user's home folder.
+# We also want JULIA_PROJECT set up so that by default they
+# get the stack of their home packages ontop of the image packages.
+# Finally, we need to load the registry while making this image
+# but then need to clear it so that the user re-loads it into their 
+# home folder (otherwise all package versions are frozen at the time
+# this image is created).
+
+# Pluto by default does track all notebook dependencies internally,
+# but we want to fall back on best-practices if the user opts
+# out of the default automatic handling.
+
+# install the global Julia packages in /opt/julia instead of $HOME
+ENV JULIA_DEPOT_PATH=/opt/julia
+ENV JULIA_PKGDIR=/opt/julia
+RUN mkdir "${JULIA_PKGDIR}" && mkdir "${JULIA_PKGDIR}/artifacts"
+
 ENV PATH="/julia-1.7.2/bin:${PATH}"
 RUN echo "PATH: ${PATH}"
 
+# Copy a script that we will use to correct permissions after running certain commands
+COPY fix-permissions /usr/local/bin/fix-permissions
+RUN chmod a+rx /usr/local/bin/fix-permissions
+
+
+# Install Pluto etc.
+
+# This could be done more carefully by copying in a Julia Project.toml and/or Manifest.toml
+# to ensure reproducibility. Here, we just get the latest versions of each.
+# Once complete, create a custom "sys-image" to compile Pluto into the Julia binary.
+# Then it will start almost instantly.
+# We do this all in one step to avoid inflating the image size with temporary steps.
+
+# One cautionary note about this approach: since these packages are now baked into the Julia
+# binary (through PlutoSysImg.so) users can't download and load other versions. This is fine
+# for e.g. Pluto but might cause issues if they install a new package that is incompatible with
+# a transitive dependency like requiring an old version of HTML.jl
+
+RUN julia -e 'using Pkg; Pkg.add(["Pluto", "PlutoUI", "PackageCompiler"]); using PackageCompiler; create_sysimage([:Pluto, :PlutoUI], sysimage_path="/PlutoSysImg.so")' && \
+    rm -rf ${JULIA_DEPOT_PATH}/registries/General && \
+    chmod -R 755 ${JULIA_DEPOT_PATH}/artifacts && \
+    fix-permissions /julia* /opt/julia PlutoSysImg.so
+
 RUN mkdir /skaha
 ADD src/startup.sh /skaha/
-RUN chmod u+x /skaha/startup.sh
+RUN chmod gou+x /skaha/startup.sh
 
-# pre-install pluto
-RUN mkdir /.julia
-RUN chmod 777 /.julia
-RUN julia -e 'using Pkg; Pkg.add("Pluto")'
 EXPOSE 1234
+
+# Network file systems do not fire file events without polling
+ENV JULIA_REVISE_POLL=1
 
 # nsswitch for correct sss lookup
 ADD src/nsswitch.conf /etc/
 
-CMD ["julia"]
+# For local testing of permissions
+# RUN useradd -ms /bin/bash tstusr
+# WORKDIR /home/newuser
+# USER tstusr
+CMD ["/skaha/startup.sh"]

--- a/containers/session-containers/skaha-pluto/VERSION
+++ b/containers/session-containers/skaha-pluto/VERSION
@@ -1,4 +1,4 @@
 ## deployable containers have a semantic and build tag
 # semantic version tag: major.minor
 # build version tag: timestamp
-TAGS="0.1 $(date -u +"%Y%m%dT%H%M%S")"
+TAGS="0.2 $(date -u +"%Y%m%dT%H%M%S")"

--- a/containers/session-containers/skaha-pluto/fix-permissions
+++ b/containers/session-containers/skaha-pluto/fix-permissions
@@ -1,0 +1,30 @@
+#!/bin/bash
+# set permissions on a directory
+# after any installation, if a directory needs to be (human) user-writable,
+# run this script on it.
+# It will make everything in the directory owned by the group ${NB_GID}
+# and writable by that group.
+# Deployments that want to set a specific user id can preserve permissions
+# by adding the `--group-add users` line to `docker run`.
+
+# uses find to avoid touching files that already have the right permissions,
+# which would cause massive image explosion
+
+# right permissions are:
+# group=${NB_GID}
+# AND permissions include group rwX (directory-execute)
+# AND directories have setuid,setgid bits set
+
+set -e
+
+for d in "$@"; do
+    find "${d}" \
+        -exec chmod go+rwX {} \;
+    # setuid, setgid *on directories only*
+    find "${d}" \
+        \( \
+            -type d \
+            -a ! -perm -6000 \
+        \) \
+        -exec chmod +6000 {} \;
+done

--- a/containers/session-containers/skaha-pluto/src/startup.sh
+++ b/containers/session-containers/skaha-pluto/src/startup.sh
@@ -1,9 +1,26 @@
-#!/bin/bash
+#!/bin/bash -e
 
 echo "Starting pluto session"
 echo "HOME: ${HOME}"
+echo "USER: $(whoami)"
+echo "Ensuring .julia directory exists for this user"
+mkdir -p "$HOME/.julia"
 
-julia -e 'using Pkg; Pkg.add("Pluto"); import Pluto; Pluto.run(require_secret_for_access=false, launch_browser=false, host="0.0.0.0")'
+# These variables set up new packages to go into the user's persistent .julia directory,
+# and keep the project/manifest in their home directory by default,
+# while retaining access to the packages we pre-bake into the container.
+# Basically, the user will have full control & reproducibility of their packages,
+# with the exception of the above pre-baked / compiled ones.
+
+
+# New pacakges get installed into here:
+export JULIA_DEPOT_PATH="$HOME/.julia:$JULIA_DEPOT_PATH"
+# Packages can get loaded from both depots
+export JULIA_LOAD_PATH="/opt/julia/environments/v1.7/Project.toml:"
+# Default project environment kept in the user's home directory
+export JULIA_PROJECT="$HOME"
+
+julia -t auto -J /PlutoSysImg.so -e 'using Pluto; Pluto.run(require_secret_for_access=false, auto_reload_from_file=true, launch_browser=false, host="0.0.0.0")'
 
 echo "Exiting"
 


### PR DESCRIPTION
Unlike Python, we don't want to create a mega image with all useful packages since Pluto auto-installs them as needed and manages versions. But this means users might end up installing things again and again each time they launch.

This PR does a few things to improve the launch speed of the Pluto image and cut down on this duplicated work:
* Pre-installs Pluto into a global environment in the image
* Sets the users' personal environments to be stacked on top of the global, pre-baked environment.
* Ensures packages installed while using a notebook are persisted (cached) into the users home folder.
* Uses Julia's PackageCompiler to compile the Pluto software into the a julia "sys-image" (basically a static shared library).
* Carefully combines commands to minimize the image size

Overall this makes it much faster to launch, and prevents unnecessary work each time a Pluto session is started.

A future optimization would be to move the Julia caching into a project folder to be shared by all users.


