### PR TITLE
Forward the requested number of cores when launching Pluto

### DIFF
--- a/containers/session-containers/skaha-pluto/src/startup.sh
+++ b/containers/session-containers/skaha-pluto/src/startup.sh
@@ -20,7 +20,7 @@ export JULIA_LOAD_PATH="/opt/julia/environments/v1.7/Project.toml:"
 # Default project environment kept in the user's home directory
 export JULIA_PROJECT="$HOME"
 
-julia -t auto -J /PlutoSysImg.so -e 'using Pluto; Pluto.run(require_secret_for_access=false, auto_reload_from_file=true, launch_browser=false, host="0.0.0.0")'
+julia -J /PlutoSysImg.so -e 'using Pluto; Pluto.run(require_secret_for_access=false, auto_reload_from_file=true, launch_browser=false, host="0.0.0.0")'
 
 echo "Exiting"
 

--- a/deployment/k8s-config/kustomize/base/skaha/config/launch-notebook.yaml
+++ b/deployment/k8s-config/kustomize/base/skaha/config/launch-notebook.yaml
@@ -56,6 +56,14 @@ spec:
           value: "/arc/home/${skaha.userid}"
         - name: XDG_CACHE_HOME
           value: "/arc/home/${skaha.userid}"
+        - name: JULIA_NUM_THREADS
+          value: "${software.requests.cores}"
+        - name: OPENBLAS_NUM_THREADS
+          value: "${software.requests.cores}"
+        - name: MKL_NUM_THREADS
+          value: "${software.requests.cores}"
+        - name: OMP_NUM_THREADS
+          value: "${software.requests.cores}"
         image: ${software.imageid}
         command: ["/skaha-system/start-jupyterlab.sh"]
         args:

--- a/deployment/k8s-config/kustomize/base/skaha/config/launch-pluto.yaml
+++ b/deployment/k8s-config/kustomize/base/skaha/config/launch-pluto.yaml
@@ -42,6 +42,12 @@ spec:
           value: "/arc/home/${skaha.userid}"
         - name: PWD
           value: "/arc/home/${skaha.userid}"
+        - name: JULIA_NUM_THREADS
+          value: "${software.requests.cores}"
+        - name: OPENBLAS_NUM_THREADS
+          value: "${software.requests.cores}"
+        - name: MKL_NUM_THREADS
+          value: "${software.requests.cores}"
         image: ${software.imageid}
         command: ["/skaha/startup.sh"]
         imagePullPolicy: Always

--- a/deployment/k8s-config/kustomize/base/skaha/config/launch-pluto.yaml
+++ b/deployment/k8s-config/kustomize/base/skaha/config/launch-pluto.yaml
@@ -48,6 +48,8 @@ spec:
           value: "${software.requests.cores}"
         - name: MKL_NUM_THREADS
           value: "${software.requests.cores}"
+        - name: OMP_NUM_THREADS
+          value: "${software.requests.cores}"
         image: ${software.imageid}
         command: ["/skaha/startup.sh"]
         imagePullPolicy: Always

--- a/deployment/k8s-config/kustomize/overlays/keel-dev/skaha/config/launch-notebook.yaml
+++ b/deployment/k8s-config/kustomize/overlays/keel-dev/skaha/config/launch-notebook.yaml
@@ -56,6 +56,14 @@ spec:
           value: "/arc/home/${skaha.userid}"
         - name: XDG_CACHE_HOME
           value: "/arc/home/${skaha.userid}"
+        - name: JULIA_NUM_THREADS
+          value: "${software.requests.cores}"
+        - name: OPENBLAS_NUM_THREADS
+          value: "${software.requests.cores}"
+        - name: MKL_NUM_THREADS
+          value: "${software.requests.cores}"
+        - name: OMP_NUM_THREADS
+          value: "${software.requests.cores}"
         image: ${software.imageid}
         command: ["/skaha-system/start-jupyterlab.sh"]
         args:

--- a/deployment/k8s-config/kustomize/overlays/keel-dev/skaha/config/launch-pluto.yaml
+++ b/deployment/k8s-config/kustomize/overlays/keel-dev/skaha/config/launch-pluto.yaml
@@ -48,6 +48,8 @@ spec:
           value: "${software.requests.cores}"
         - name: MKL_NUM_THREADS
           value: "${software.requests.cores}"
+        - name: OMP_NUM_THREADS
+          value: "${software.requests.cores}"
         image: ${software.imageid}
         command: ["/skaha/startup.sh"]
         imagePullPolicy: Always

--- a/deployment/k8s-config/kustomize/overlays/keel-dev/skaha/config/launch-pluto.yaml
+++ b/deployment/k8s-config/kustomize/overlays/keel-dev/skaha/config/launch-pluto.yaml
@@ -42,6 +42,8 @@ spec:
           value: "/arc/home/${skaha.userid}"
         - name: PWD
           value: "/arc/home/${skaha.userid}"
+        - name: JULIA_NUM_THREADS
+          value: "${software.requests.cores}"
         image: ${software.imageid}
         command: ["/skaha/startup.sh"]
         imagePullPolicy: Always

--- a/deployment/k8s-config/kustomize/overlays/keel-dev/skaha/config/launch-pluto.yaml
+++ b/deployment/k8s-config/kustomize/overlays/keel-dev/skaha/config/launch-pluto.yaml
@@ -44,6 +44,10 @@ spec:
           value: "/arc/home/${skaha.userid}"
         - name: JULIA_NUM_THREADS
           value: "${software.requests.cores}"
+        - name: OPENBLAS_NUM_THREADS
+          value: "${software.requests.cores}"
+        - name: MKL_NUM_THREADS
+          value: "${software.requests.cores}"
         image: ${software.imageid}
         command: ["/skaha/startup.sh"]
         imagePullPolicy: Always


### PR DESCRIPTION
Continuing a slack conversation with @brianmajor ...

Julia processes, including Pluto notebooks, can easily make use of multiple threads if available.
But the normal way of detecting the number of cores (`julia -t auto`) always returns the number of physical cores on the node.
As an example, this leads to running with 32 threads when only 2 cores are provisioned, hurting performance.

If I understand Kubenetes, and I'm sure that I *don't*, this change will forward this information from Kubernetes to julia using the `software.requests.cores` and `JULIA_NUM_THREADS` environment variable. 

Unfortunately I don't have a way to test this change locally.
If this does work, I recommend we make a similar change to the other session containers. Most numerical software including Numpy (and probably Carta) falls back on BLAS libraries for matrix multiplication. To prevent the same oversubscription issue, we should set `OPENBLAS_NUM_THREADS` and `MKL_NUM_THREADS` to cover all our bases. 

