### PR TITLE
add k8s-config files for CASTOR ETC GUI

### DIFF
--- a/deployment/k8s-config/kustomize/base/skaha/config/ingress-castor-etc.yaml
+++ b/deployment/k8s-config/kustomize/base/skaha/config/ingress-castor-etc.yaml
@@ -1,0 +1,28 @@
+# apiVersion: traefik.containo.us/v1alpha1
+# kind: Middleware
+# metadata:
+#   name: skaha-castor-etc-middleware-${skaha.sessionid}
+# spec:
+#   replacePathRegex:
+#     regex: ^/session/castor-etc/${skaha.sessionid}(/|$)(.*)
+#     replacement: /$2
+
+# ---
+
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: skaha-castor-etc-ingress-${skaha.sessionid}
+spec:
+  entryPoints:
+    - web
+  routes:
+  - kind: Rule
+    match: Host(`ws-uv.canfar.net`) && PathPrefix(`/session/castor-etc/${skaha.sessionid}/`)
+    services:
+    - kind: Service
+      name: skaha-castor-etc-svc-${skaha.sessionid}
+      port: 5000
+      scheme: http
+    # middlewares:
+    #   - name: skaha-castor-etc-middleware-${skaha.sessionid}

--- a/deployment/k8s-config/kustomize/base/skaha/config/launch-castor-etc.yaml
+++ b/deployment/k8s-config/kustomize/base/skaha/config/launch-castor-etc.yaml
@@ -40,6 +40,8 @@ spec:
           value: "${skaha.userid}"
         image: ${software.imageid}
         command: ["/skaha/startup.sh"]
+        args:
+        - debug  # verbosity level of logs
         imagePullPolicy: Always
         resources:
           requests:

--- a/deployment/k8s-config/kustomize/base/skaha/config/launch-castor-etc.yaml
+++ b/deployment/k8s-config/kustomize/base/skaha/config/launch-castor-etc.yaml
@@ -41,6 +41,7 @@ spec:
         image: ${software.imageid}
         command: ["/skaha/startup.sh"]
         args:
+        - ${skaha.sessionid}  # for URL routing
         - debug  # verbosity level of logs
         imagePullPolicy: Always
         resources:

--- a/deployment/k8s-config/kustomize/base/skaha/config/launch-castor-etc.yaml
+++ b/deployment/k8s-config/kustomize/base/skaha/config/launch-castor-etc.yaml
@@ -1,0 +1,84 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    canfar-net-sessionID: "${skaha.sessionid}"
+    canfar-net-sessionName: "${skaha.sessionname}"
+    canfar-net-sessionType: "${skaha.sessiontype}"
+    canfar-net-userid: "${skaha.userid}"
+  name: "${skaha.jobname}"
+spec:
+  activeDeadlineSeconds: 1209600
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        canfar-net-sessionID: "${skaha.sessionid}"
+        canfar-net-sessionName: "${skaha.sessionname}"
+        canfar-net-sessionType: "${skaha.sessiontype}"
+        canfar-net-userid: "${skaha.userid}"
+        job-name: "${skaha.jobname}"
+    spec:
+      restartPolicy: OnFailure
+      ${skaha.schedulegpu}
+      imagePullSecrets:
+      - name: ${software.imagesecret}
+      securityContext:
+        runAsUser: ${skaha.posixid}
+        runAsGroup: ${skaha.posixid}
+        fsGroup: ${skaha.posixid}
+        supplementalGroups: [${skaha.supgroups}]
+      priorityClassName: uber-user-preempt-medium
+      hostname: "${software.hostname}"
+      containers:
+      - name: "${skaha.jobname}"
+        env:
+        - name: skaha_hostname
+          value: "${skaha.hostname}"
+        - name: skaha_username
+          value: "${skaha.userid}"
+        image: ${software.imageid}
+        command: ["/skaha/startup.sh"]
+        imagePullPolicy: Always
+        resources:
+          requests:
+            memory: "${software.requests.ram}"
+            cpu: "${software.requests.cores}"
+            ephemeral-storage: "20Gi"
+          limits:
+            memory: "${software.limits.ram}"
+            cpu: "${software.limits.cores}"
+            ephemeral-storage: "200Gi"
+        ports:
+        - containerPort: 5000
+          protocol: TCP
+          name: main-port
+        volumeMounts:
+        # - mountPath: "/arc"
+        #   name: cavern-volume
+        #   subPath: "cavern"
+        # - mountPath: "/scratch"
+        #   name: scratch-dir
+        #   subPath: "${skaha.sessionid}"
+        - mountPath: /var/lib/sss/pipes
+          name: sssd-dir
+          readOnly: true
+      volumes:
+      - name: cavern-volume
+        cephfs:
+          monitors:
+          - 10.30.201.3:6789
+          - 10.30.202.3:6789
+          - 10.30.203.3:6789
+          path: /volumes/_nogroup/054e398e-a08e-425e-9f7c-fc394362e38e
+          user: keel_prod
+          secretRef:
+            name: cephfs-cephx-key
+          readOnly: false
+      - name: scratch-dir
+        emptyDir: {}
+      - name: sssd-dir
+        hostPath:
+          path: /var/lib/ubernetes
+          type: Directory

--- a/deployment/k8s-config/kustomize/base/skaha/config/service-castor-etc.yaml
+++ b/deployment/k8s-config/kustomize/base/skaha/config/service-castor-etc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: skaha-castor-etc-svc-${skaha.sessionid}
+  labels:
+    run: skaha-castor-etc-svc-${skaha.sessionid}
+spec:
+  ports:
+  - port: 5000
+    protocol: TCP
+    name: http-connection
+  selector:
+    canfar-net-sessionID: ${skaha.sessionid}

--- a/deployment/k8s-config/kustomize/overlays/keel-dev/skaha/config/ingress-castor-etc.yaml
+++ b/deployment/k8s-config/kustomize/overlays/keel-dev/skaha/config/ingress-castor-etc.yaml
@@ -1,0 +1,28 @@
+# apiVersion: traefik.containo.us/v1alpha1
+# kind: Middleware
+# metadata:
+#   name: skaha-castor-etc-middleware-${skaha.sessionid}
+# spec:
+#   replacePathRegex:
+#     regex: ^/session/castor-etc/${skaha.sessionid}(/|$)(.*)
+#     replacement: /$2
+
+# ---
+
+apiVersion: traefik.containo.us/v1alpha1
+kind: IngressRoute
+metadata:
+  name: skaha-castor-etc-ingress-${skaha.sessionid}
+spec:
+  entryPoints:
+    - web
+  routes:
+  - kind: Rule
+    match: Host(`rc-uv.canfar.net`) && PathPrefix(`/session/castor-etc/${skaha.sessionid}/`)
+    services:
+    - kind: Service
+      name: skaha-castor-etc-svc-${skaha.sessionid}
+      port: 5000
+      scheme: http
+    # middlewares:
+    #   - name: skaha-castor-etc-middleware-${skaha.sessionid}

--- a/deployment/k8s-config/kustomize/overlays/keel-dev/skaha/config/launch-castor-etc.yaml
+++ b/deployment/k8s-config/kustomize/overlays/keel-dev/skaha/config/launch-castor-etc.yaml
@@ -41,6 +41,7 @@ spec:
         image: ${software.imageid}
         command: ["/skaha/startup.sh"]
         args:
+        - ${skaha.sessionid}  # for URL routing
         - debug  # verbosity level of logs
         imagePullPolicy: Always
         resources:

--- a/deployment/k8s-config/kustomize/overlays/keel-dev/skaha/config/launch-castor-etc.yaml
+++ b/deployment/k8s-config/kustomize/overlays/keel-dev/skaha/config/launch-castor-etc.yaml
@@ -1,0 +1,86 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  labels:
+    canfar-net-sessionID: "${skaha.sessionid}"
+    canfar-net-sessionName: "${skaha.sessionname}"
+    canfar-net-sessionType: "${skaha.sessiontype}"
+    canfar-net-userid: "${skaha.userid}"
+  name: "${skaha.jobname}"
+spec:
+  activeDeadlineSeconds: 1209600
+  ttlSecondsAfterFinished: 86400
+  template:
+    metadata:
+      labels:
+        canfar-net-sessionID: "${skaha.sessionid}"
+        canfar-net-sessionName: "${skaha.sessionname}"
+        canfar-net-sessionType: "${skaha.sessiontype}"
+        canfar-net-userid: "${skaha.userid}"
+        job-name: "${skaha.jobname}"
+    spec:
+      restartPolicy: OnFailure
+      ${skaha.schedulegpu}
+      imagePullSecrets:
+      - name: ${software.imagesecret}
+      securityContext:
+        runAsUser: ${skaha.posixid}
+        runAsGroup: ${skaha.posixid}
+        fsGroup: ${skaha.posixid}
+        supplementalGroups: [${skaha.supgroups}]
+      priorityClassName: uber-user-preempt-medium
+      hostname: "${software.hostname}"
+      containers:
+      - name: "${skaha.jobname}"
+        env:
+        - name: skaha_hostname
+          value: "${skaha.hostname}"
+        - name: skaha_username
+          value: "${skaha.userid}"
+        image: ${software.imageid}
+        command: ["/skaha/startup.sh"]
+        args:
+        - debug  # verbosity level of logs
+        imagePullPolicy: Always
+        resources:
+          requests:
+            memory: "${software.requests.ram}"
+            cpu: "${software.requests.cores}"
+            ephemeral-storage: "20Gi"
+          limits:
+            memory: "${software.limits.ram}"
+            cpu: "${software.limits.cores}"
+            ephemeral-storage: "200Gi"
+        ports:
+        - containerPort: 5000
+          protocol: TCP
+          name: main-port
+        volumeMounts:
+        # - mountPath: "/arc"
+        #   name: cavern-volume
+        #   subPath: "cavern"
+        # - mountPath: "/scratch"
+        #   name: scratch-dir
+        #   subPath: "${skaha.sessionid}"
+        - mountPath: /var/lib/sss/pipes
+          name: sssd-dir
+          readOnly: true
+      volumes:
+      - name: cavern-volume
+        cephfs:
+          monitors:
+          - 10.30.201.3:6789
+          - 10.30.202.3:6789
+          - 10.30.203.3:6789
+          path: /volumes/_nogroup/054e398e-a08e-425e-9f7c-fc394362e38e
+          user: keel_prod
+          secretRef:
+            name: cephfs-cephx-key
+          readOnly: false
+      - name: scratch-dir
+        emptyDir: {}
+      - name: sssd-dir
+        hostPath:
+          path: /var/lib/ubernetes
+          type: Directory

--- a/deployment/k8s-config/kustomize/overlays/keel-dev/skaha/config/service-castor-etc.yaml
+++ b/deployment/k8s-config/kustomize/overlays/keel-dev/skaha/config/service-castor-etc.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: skaha-castor-etc-svc-${skaha.sessionid}
+  labels:
+    run: skaha-castor-etc-svc-${skaha.sessionid}
+spec:
+  ports:
+  - port: 5000
+    protocol: TCP
+    name: http-connection
+  selector:
+    canfar-net-sessionID: ${skaha.sessionid}


### PR DESCRIPTION
The Dockerfile and other source code are in a private repository. I tried to emulate the `pluto` container type.

Also, originally I had the following line at the end of my Dockerfile:

```dockerfile
CMD ["gunicorn", "-b", "0.0.0.0:5000", "connector:app", "--log-level=debug", "--log-file=/dev/stdout"]
```

But since I'm not sure if the `command` entry in `launch-castor-etc.yaml` is required, I replaced the line above with the following code:

```dockerfile
ADD docker/startup.sh /skaha/
RUN chmod u+x /skaha/startup.sh
```

with `startup.sh` containing:
```bash
#!/bin/bash
LOGLEVEL=${1:-debug}
echo "Starting gunicorn..."
cd /backend
gunicorn -b 0.0.0.0:5000 connector:app --log-level=${LOGLEVEL} --log-file=/dev/stdout
```

