### PR TITLE
CADC-11740 Update from CARTA-beta to CARTA 3.0.

### DIFF
--- a/containers/session-containers/skaha-carta/v3/Dockerfile
+++ b/containers/session-containers/skaha-carta/v3/Dockerfile
@@ -2,9 +2,9 @@ FROM ubuntu:20.04
 
 RUN apt update && \
     apt install -y software-properties-common && \
-    add-apt-repository ppa:cartavis-team/carta-testing && \
+    add-apt-repository ppa:cartavis-team/carta && \
     apt update && \
-    apt install -y carta-beta
+    apt install -y carta
 
 RUN mkdir /carta
 WORKDIR /carta

--- a/containers/session-containers/skaha-carta/v3/Makefile
+++ b/containers/session-containers/skaha-carta/v3/Makefile
@@ -1,6 +1,6 @@
 
 NAME = images.canfar.net/skaha/carta
-VERSION = 3.0-beta
+VERSION = 3.0
 
 build: dependencies Dockerfile
 	docker build -t $(NAME):$(VERSION) -f Dockerfile .

--- a/containers/session-containers/skaha-carta/v3/README.md
+++ b/containers/session-containers/skaha-carta/v3/README.md
@@ -2,14 +2,14 @@
 
 ## About
 
-A CARTA 3.0 beta session container for skaha based on CARTA-remote (https://github.com/CARTAvis).
+A CARTA 3.0 session container for skaha based on CARTA-remote (https://github.com/CARTAvis).
 
 A wrapper script, `skaha-carta`, is added to the container that calls the CARTA binary `carta`.
 
 ## Building
 
 ```
-docker build -t images.canfar.net/skaha/carta:3.0-beta -f Dockerfile .
+docker build -t images.canfar.net/skaha/carta:3.0 -f Dockerfile .
 ```
 
 ## Publishing to the image registry


### PR DESCRIPTION
<img width="1191" alt="Screen Shot 2022-09-01 at 3 32 48 PM" src="https://user-images.githubusercontent.com/8481544/188024394-2f20781b-fb84-4049-8a02-2bbd6780353c.png">


Log output of skaha-carta:
```
[yeunga@keel-dev-login ~]$ kw logs skaha-carta-alinga-hvpl0vsu-9ll85
Thu Sep  1 22:19:13 UTC 2022 skaha-carta START
root: /arc
folder: /arc/projects
command: carta --no_browser --top_level_folder=/arc --port=6901 --idle_timeout=100000 --debug_no_auth /arc/projects
[2022-09-01 22:19:13.625] [CARTA] [info] Writing to the log file: /carta/.carta/log/carta.log
[2022-09-01 22:19:13.625] [CARTA] [info] /usr/bin/carta_backend: Version 3.0.0
[2022-09-01 22:19:13.626] [CARTA] [info] Serving CARTA frontend from /usr/share/carta/frontend
[2022-09-01 22:19:13.626] [CARTA] [info] Listening on port 6901 with top level folder /arc, starting folder /arc/projects. The number of OpenMP worker threads will be handled automatically.
[2022-09-01 22:19:13.626] [CARTA] [info] CARTA is accessible at http://10.233.117.205:6901
[2022-09-01 22:20:05.340] [CARTA] [info] 0x565249e70670 ::Session (66167336:1)
[2022-09-01 22:20:05.340] [CARTA] [info] Session 66167336 [192.168.243.220] Connected. Num sessions: 1
```