### PR TITLE
Cadc 11777

### DIFF
--- a/deployment/k8s-config/scripts/deadline.sh
+++ b/deployment/k8s-config/scripts/deadline.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+JOBFILE=jobs.txt
+WORKSPACE=skaha-workload
+
+#Make a list off all jobs, excluding headless batch jobs:
+kubectl -n $WORKSPACE get jobs | grep -Eiv "headless" | awk '{print $1}'ls > $JOBFILE
+
+#Loop through jobs in list and set activeDeadlineSeconds to new value:
+while read J; do
+  kubectl -n $WORKSPACE patch job $J --type='json' -p '[{"op":"add","path":"/spec/activeDeadlineSeconds", "value":1814400}]'
+done <$JOBFILE
+

--- a/deployment/k8s-config/scripts/deadline.sh
+++ b/deployment/k8s-config/scripts/deadline.sh
@@ -1,12 +1,14 @@
 #!/bin/bash
-JOBFILE=jobs.txt
+
+DEADLINE=1814400
 WORKSPACE=skaha-workload
+JOBFILE=jobs.txt
 
 #Make a list off all jobs, excluding headless batch jobs:
 kubectl -n $WORKSPACE get jobs | grep -Eiv "headless" | awk '{print $1}'ls > $JOBFILE
 
 #Loop through jobs in list and set activeDeadlineSeconds to new value:
 while read J; do
-  kubectl -n $WORKSPACE patch job $J --type='json' -p '[{"op":"add","path":"/spec/activeDeadlineSeconds", "value":1814400}]'
+  kubectl -n $WORKSPACE patch job $J --type='json' -p '[{"op":"add","path":"/spec/activeDeadlineSeconds", "value":'$DEADLINE'}]'
 done <$JOBFILE
 


### PR DESCRIPTION
Added a new script to set the activeDeadlineSeconds variable for running jobs. This lets us control when jobs terminate, especially useful when the Science Platform front end and authentification are offline.