### PR TITLE
CADC-11734 Fixed commands with large (larger than 64Ki) outputs hanging in SessionAction

### DIFF
--- a/deployment/k8s-config/kustomize/base/skaha/skaha-tomcat-deployment.yaml
+++ b/deployment/k8s-config/kustomize/base/skaha/skaha-tomcat-deployment.yaml
@@ -38,7 +38,7 @@ spec:
           value: "ivo://cadc.nrc.ca/gms?skaha-users"
         - name: skaha.adminsgroup
           value: "ivo://cadc.nrc.ca/gms?skaha-admins"
-        image: images.canfar.net/skaha-system/skaha:0.9.7
+        image: images.canfar.net/skaha-system/skaha:0.9.8
         imagePullPolicy: Always
         #imagePullPolicy: IfNotPresent
         name: skaha-tomcat

--- a/deployment/k8s-config/kustomize/overlays/keel-dev/skaha/skaha-tomcat-deployment.yaml
+++ b/deployment/k8s-config/kustomize/overlays/keel-dev/skaha/skaha-tomcat-deployment.yaml
@@ -16,7 +16,7 @@ spec:
           value: "ivo://cadc.nrc.ca/gms?skaha-users"
         - name: skaha.adminsgroup
           value: "ivo://cadc.nrc.ca/gms?skaha-admins"
-        image: images-rc.canfar.net/skaha-system/skaha:0.9.7
+        image: images-rc.canfar.net/skaha-system/skaha:0.9.8
         resources:
           requests:
             memory: "4Gi"

--- a/skaha/VERSION
+++ b/skaha/VERSION
@@ -1,4 +1,4 @@
 ## deployable containers have a semantic and build tag
 # semantic version tag: major.minor
 # build version tag: timestamp
-TAGS="0.9.7 $(date -u +"%Y%m%dT%H%M%S")"
+TAGS="0.9.8 $(date -u +"%Y%m%dT%H%M%S")"

--- a/skaha/src/main/java/org/opencadc/skaha/session/GetAction.java
+++ b/skaha/src/main/java/org/opencadc/skaha/session/GetAction.java
@@ -163,11 +163,14 @@ public class GetAction extends SessionAction {
             int withCores = 0;
             int withRAM = 0;
             Map<String, Integer> rCPUCoreMap = getCPUCores(k8sNamespace);
-            log.debug("done getting CPU cores");
             Map<String, int[]> aResourceMap = getAvailableResources(k8sNamespace);
             List<String> nodeNames = rCPUCoreMap.keySet().stream().collect(Collectors.toList());
             for (String nodeName : nodeNames) {
                 int[] aResources = aResourceMap.get(nodeName);
+                if (aResources == null) {
+                    aResources = new int[] {0, 0};
+                }
+
                 int aCPUCores = aResources[0];
                 if (aCPUCores > maxCores) {
                     maxCores = aCPUCores;
@@ -237,9 +240,7 @@ public class GetAction extends SessionAction {
 
     private Map<String, int[]> getAvailableResources(String k8sNamespace) throws Exception {
         String getAvailableResourcesCmd = "kubectl -n " + k8sNamespace + " describe nodes ";
-        log.debug("command to get available resources: " + getAvailableResourcesCmd);
         String rawResources = execute(getAvailableResourcesCmd.split(" "));
-        log.debug("got the described nodes");
         Map<String, int[]> nodeToResourcesMap = new HashMap<String, int[]>();
         if (StringUtil.hasLength(rawResources)) {
             String[] lines = rawResources.split("\n");

--- a/skaha/src/main/java/org/opencadc/skaha/session/SessionAction.java
+++ b/skaha/src/main/java/org/opencadc/skaha/session/SessionAction.java
@@ -195,12 +195,12 @@ public abstract class SessionAction extends SkahaAction {
     
     public static String execute(String[] command, boolean allowError) throws IOException, InterruptedException {
         Process p = Runtime.getRuntime().exec(command);
-        int status = p.waitFor();
-        log.debug("Status=" + status + " for command: " + Arrays.toString(command));
         String stdout = readStream(p.getInputStream());
         String stderr = readStream(p.getErrorStream());
         log.debug("stdout: " + stdout);
         log.debug("stderr: " + stderr);
+        int status = p.waitFor();
+        log.debug("Status=" + status + " for command: " + Arrays.toString(command));
         if (status != 0) {
             if (allowError) {
                 return stderr;


### PR DESCRIPTION
Also fixed a potential NullPointerException in session/GetAction.

The cause of the "kubectl -n Skaha-workload describe nodes" command to hang is that the output of the command is larger than the buffer (64Ki ?) and the process is blocked until there is buffer space available. So a solution is to unload the buffer by streaming to stdout and stderr first, then wait for the process to finish. 
