### PR TITLE
CADC-11734 Corrected session count and total count to count only 'Run…

### DIFF
--- a/deployment/k8s-config/kustomize/base/skaha/skaha-tomcat-deployment.yaml
+++ b/deployment/k8s-config/kustomize/base/skaha/skaha-tomcat-deployment.yaml
@@ -38,7 +38,7 @@ spec:
           value: "ivo://cadc.nrc.ca/gms?skaha-users"
         - name: skaha.adminsgroup
           value: "ivo://cadc.nrc.ca/gms?skaha-admins"
-        image: images.canfar.net/skaha-system/skaha:0.9.8
+        image: images.canfar.net/skaha-system/skaha:0.9.9
         imagePullPolicy: Always
         #imagePullPolicy: IfNotPresent
         name: skaha-tomcat

--- a/deployment/k8s-config/kustomize/overlays/keel-dev/skaha/skaha-tomcat-deployment.yaml
+++ b/deployment/k8s-config/kustomize/overlays/keel-dev/skaha/skaha-tomcat-deployment.yaml
@@ -16,7 +16,7 @@ spec:
           value: "ivo://cadc.nrc.ca/gms?skaha-users"
         - name: skaha.adminsgroup
           value: "ivo://cadc.nrc.ca/gms?skaha-admins"
-        image: images-rc.canfar.net/skaha-system/skaha:0.9.8
+        image: images-rc.canfar.net/skaha-system/skaha:0.9.9
         resources:
           requests:
             memory: "4Gi"

--- a/skaha/VERSION
+++ b/skaha/VERSION
@@ -1,4 +1,4 @@
 ## deployable containers have a semantic and build tag
 # semantic version tag: major.minor
 # build version tag: timestamp
-TAGS="0.9.8 $(date -u +"%Y%m%dT%H%M%S")"
+TAGS="0.9.9 $(date -u +"%Y%m%dT%H%M%S")"

--- a/skaha/src/main/java/org/opencadc/skaha/session/GetAction.java
+++ b/skaha/src/main/java/org/opencadc/skaha/session/GetAction.java
@@ -153,10 +153,10 @@ public class GetAction extends SessionAction {
         List<Session> sessions = getAllSessions(null);
         int desktopCount = filter(sessions, "desktop-app", "Running").size();
         int headlessCount = filter(sessions, "headless", "Running").size();
-        int totalCount = sessions.size();
+        int totalCount = filter(sessions, null, "Running").size();
         String k8sNamespace = K8SUtil.getWorkloadNamespace();
         try {
-            int coresInUse = 0;
+            int requestedCPUCores = 0;
             int coresAvailable = 0;
             int maxCores = 0;
             int maxRAM = 0;
@@ -184,7 +184,7 @@ public class GetAction extends SessionAction {
                 }
                 
                 int rCPUCores = rCPUCoreMap.get(nodeName);
-                coresInUse = coresInUse + rCPUCores;
+                requestedCPUCores = requestedCPUCores + rCPUCores;
                 coresAvailable = coresAvailable + aCPUCores;
                 log.debug("Node: " + nodeName + " Cores: " + rCPUCores + "/" + aCPUCores + " RAM: " + aRAM + " Ki");
             }
@@ -192,7 +192,7 @@ public class GetAction extends SessionAction {
             // convert RAM unit from Ki to Gi
             String withRAMStr = String.valueOf(withRAM/1048576) + "Gi";
             String maxRAMStr = String.valueOf(maxRAM/1048576) + "Gi";
-            return new ResourceStats(desktopCount, headlessCount, totalCount, coresInUse, coresAvailable, maxCores, withRAMStr, maxRAMStr, withCores);
+            return new ResourceStats(desktopCount, headlessCount, totalCount, requestedCPUCores, coresAvailable, maxCores, withRAMStr, maxRAMStr, withCores);
         } catch (Exception e) {
             log.error(e);
             throw new IllegalStateException("failed to gather resource statistics", e);

--- a/skaha/src/main/java/org/opencadc/skaha/session/ResourceStats.java
+++ b/skaha/src/main/java/org/opencadc/skaha/session/ResourceStats.java
@@ -81,7 +81,7 @@ public class ResourceStats {
     private Ram ram;
 
     public ResourceStats(int desktopCount, int headlessCount, int totalCount, 
-            int coresInUse, int coresAvailable, int mCores, String withRAM, String mRAM, int withCores) {
+            int requestedCPUCores, int coresAvailable, int mCores, String withRAM, String mRAM, int withCores) {
         instances = new JobInstances(desktopCount, headlessCount, totalCount);
 
         MaxCoreResource maxCores = new MaxCoreResource();
@@ -90,7 +90,7 @@ public class ResourceStats {
         cores = new Core();
         cores.maxCores = maxCores;
         cores.coresAvailable = coresAvailable;
-        cores.coresInUse = coresInUse;
+        cores.requestedCPUCores = requestedCPUCores;
 
         MaxRamResource maxRAM = new MaxRamResource();
         maxRAM.ram = mRAM;
@@ -114,7 +114,7 @@ public class ResourceStats {
     }
     
     class Core {
-        int coresInUse = 0;
+        int requestedCPUCores = 0;
         int coresAvailable = 0;
         MaxCoreResource maxCores;
     }


### PR DESCRIPTION
…ning' sessions. Renamed 'coresInUse' to 'requestedCPUCores'.

Output from keel-dev:

```
% curl -E ~/.ssl/cadcproxy.pem  "https://rc-uv.canfar.net/skaha/session?view=stats"
{
  "instances": {
    "session": 5,
    "desktopApp": 1,
    "headless": 0,
    "total": 6
  },
  "cores": {
    "requestedCPUCores": 8,
    "coresAvailable": 32,
    "maxCores": {
      "cores": 32,
      "withRam": "147Gi"
    }
  },
  "ram": {
    "maxRAM": {
      "ram": "147Gi",
      "withCores": 32
    }
  }
}
```