### PR TITLE
CSD-3299: config change for session-desktop.yaml to isolate container selection

### DIFF
--- a/deployment/k8s-config/kustomize/base/skaha/config/service-desktop.yaml
+++ b/deployment/k8s-config/kustomize/base/skaha/config/service-desktop.yaml
@@ -11,3 +11,4 @@ spec:
     name: http-connection
   selector:
     canfar-net-sessionID: ${skaha.sessionid}
+    canfar-net-sessionType: desktop

--- a/deployment/k8s-config/kustomize/base/skaha/skaha-tomcat-deployment.yaml
+++ b/deployment/k8s-config/kustomize/base/skaha/skaha-tomcat-deployment.yaml
@@ -38,7 +38,7 @@ spec:
           value: "ivo://cadc.nrc.ca/gms?skaha-users"
         - name: skaha.adminsgroup
           value: "ivo://cadc.nrc.ca/gms?skaha-admins"
-        image: images.canfar.net/skaha-system/skaha:0.9.9
+        image: images.canfar.net/skaha-system/skaha:0.9.10
         imagePullPolicy: Always
         #imagePullPolicy: IfNotPresent
         name: skaha-tomcat


### PR DESCRIPTION
Isolate selection of desktop instances from any desktop-app instances in a group of related desktop session containers. Related containers have the same sessionID, so the existing selector could return with a container that could not be connected to. 

Symptom on system: on connecting to a desktop session, there'd be intermittent 502 issues, or the arcade launch page would display three dots, or just return to the 'connect' button display with a websocket error. 