### PR TITLE
Reduce session lifetime from 2 weeks to 4 days (CADC-12165)

### DIFF
--- a/deployment/k8s-config/kustomize/base/skaha/config/launch-headless.yaml
+++ b/deployment/k8s-config/kustomize/base/skaha/config/launch-headless.yaml
@@ -9,7 +9,7 @@ metadata:
     canfar-net-userid: "${skaha.userid}"
   name: "${skaha.jobname}"
 spec:
-  activeDeadlineSeconds: ${skaha.sessionexpiry}
+  activeDeadlineSeconds: 1209600
   ttlSecondsAfterFinished: 3600
   backoffLimit: 0
   template:

--- a/deployment/k8s-config/kustomize/base/skaha/skaha-tomcat-deployment.yaml
+++ b/deployment/k8s-config/kustomize/base/skaha/skaha-tomcat-deployment.yaml
@@ -33,7 +33,7 @@ spec:
         - name: skaha.maxusersessions
           value: "3"
         - name: skaha.sessionexpiry
-          value: "1209600"
+          value: "345600"
         - name: skaha.harborhosts
           value: "images.canfar.net"
         - name: skaha.usersgroup

--- a/deployment/k8s-config/kustomize/overlays/keel-dev/skaha/config/launch-headless.yaml
+++ b/deployment/k8s-config/kustomize/overlays/keel-dev/skaha/config/launch-headless.yaml
@@ -9,7 +9,7 @@ metadata:
     canfar-net-userid: "${skaha.userid}"
   name: "${skaha.jobname}"
 spec:
-  activeDeadlineSeconds: ${skaha.sessionexpiry}
+  activeDeadlineSeconds: 1209600
   ttlSecondsAfterFinished: 60
   backoffLimit: 0
   template:

--- a/deployment/k8s-config/kustomize/overlays/keel-dev/skaha/skaha-tomcat-deployment.yaml
+++ b/deployment/k8s-config/kustomize/overlays/keel-dev/skaha/skaha-tomcat-deployment.yaml
@@ -17,7 +17,7 @@ spec:
         - name: skaha.adminsgroup
           value: "ivo://cadc.nrc.ca/gms?skaha-admins"
         - name: skaha.sessionexpiry
-          value: "1209600"
+          value: "345600"
         image: images-rc.canfar.net/skaha-system/skaha:0.9.12
         resources:
           requests:


### PR DESCRIPTION
With the goal of freeing up resources held by idle interactive sessions, reduce the lifetime of the session from 2 weeks to 4 days.  Active users have the option of renewing their sessions indefinitely.

Headless sessions will retain the 2 week lifetime.  Renewals of headless sessions add 4 days.

@yeunga Could you please review this PR when you have a chance?