### PR TITLE
VS Code web session container

### DIFF
--- a/containers/session-containers/vscode/Dockerfile
+++ b/containers/session-containers/vscode/Dockerfile
@@ -10,6 +10,8 @@ RUN mkdir /skaha
 ADD src/startup.sh /skaha/
 RUN chmod gou+x /skaha/startup.sh
 
+RUN apt-get install --yes sssd && rm -rf /var/lib/apt/lists/*
+
 USER coder
 EXPOSE 5000
 

--- a/containers/session-containers/vscode/Dockerfile
+++ b/containers/session-containers/vscode/Dockerfile
@@ -1,0 +1,16 @@
+FROM codercom/code-server
+
+#FROM gitpod/openvscode-server:latest
+
+# nsswitch for correct sss lookup
+ADD src/nsswitch.conf /etc/
+
+USER root
+RUN mkdir /skaha
+ADD src/startup.sh /skaha/
+RUN chmod gou+x /skaha/startup.sh
+
+USER jovyan
+EXPOSE 5000
+
+ENTRYPOINT [ "/skaha/startup.sh" ]

--- a/containers/session-containers/vscode/Dockerfile
+++ b/containers/session-containers/vscode/Dockerfile
@@ -10,7 +10,7 @@ RUN mkdir /skaha
 ADD src/startup.sh /skaha/
 RUN chmod gou+x /skaha/startup.sh
 
-USER jovyan
+USER coder
 EXPOSE 5000
 
 ENTRYPOINT [ "/skaha/startup.sh" ]

--- a/containers/session-containers/vscode/src/nsswitch.conf
+++ b/containers/session-containers/vscode/src/nsswitch.conf
@@ -1,0 +1,62 @@
+#
+# /etc/nsswitch.conf
+#
+# An example Name Service Switch config file. This file should be
+# sorted with the most-used services at the beginning.
+#
+# The entry '[NOTFOUND=return]' means that the search for an
+# entry should stop if the search in the previous entry turned
+# up nothing. Note that if the search failed due to some other reason
+# (like no NIS server responding) then the search continues with the
+# next entry.
+#
+# Valid entries include:
+#
+#	nisplus			Use NIS+ (NIS version 3)
+#	nis			Use NIS (NIS version 2), also called YP
+#	dns			Use DNS (Domain Name Service)
+#	files			Use the local files
+#	db			Use the local database (.db) files
+#	compat			Use NIS on compat mode
+#	hesiod			Use Hesiod for user lookups
+#	[NOTFOUND=return]	Stop searching if not found so far
+#
+
+# To use db, put the "db" in front of "files" for entries you want to be
+# looked up first in the databases
+#
+# Example:
+#passwd:    db files nisplus nis
+#shadow:    db files nisplus nis
+#group:     db files nisplus nis
+
+passwd:     sss files
+shadow:     files sss
+group:      sss files
+
+#hosts:     db files nisplus nis dns
+hosts:      files dns
+
+# Example - obey only what nisplus tells us...
+#services:   nisplus [NOTFOUND=return] files
+#networks:   nisplus [NOTFOUND=return] files
+#protocols:  nisplus [NOTFOUND=return] files
+#rpc:        nisplus [NOTFOUND=return] files
+#ethers:     nisplus [NOTFOUND=return] files
+#netmasks:   nisplus [NOTFOUND=return] files
+
+bootparams: nisplus [NOTFOUND=return] files
+
+ethers:     files
+netmasks:   files
+networks:   files
+protocols:  files
+rpc:        files
+services:   files
+
+netgroup:   nisplus
+
+publickey:  nisplus
+
+automount:  files nisplus
+aliases:    files nisplus

--- a/containers/session-containers/vscode/src/startup.sh
+++ b/containers/session-containers/vscode/src/startup.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -e
+
+echo "Starting VS code session"
+echo "HOME: ${HOME}"
+echo "USER: $(whoami)"
+
+mkdir -p ~/.config/code-server
+
+echo "bind-addr: 127.0.0.1:8080" > ~/.config/code-server/config.yaml
+echo "auth: none" >> ~/.config/code-server/config.yaml
+echo "cert: false" >> ~/.config/code-server/config.yaml
+
+/usr/bin/entrypoint.sh --bind-addr 0.0.0.0:5000 ~
+
+echo "Exiting"
+


### PR DESCRIPTION
This session container should allow the user to launch the VS Code editor in their browser.
As it stands, they can install extensions, browse files in `/arc`, etc. Multiple folders can be opened simultaneously by opening the URL in multiple tabs/windows.

I imagine it could be useful to use a full editor in one tab while running e.g. notebooks in another.

This version does not come with anaconda, pluto, or any other data science software installed. I suppose that could be layered on top of this in a second image.

To make sure that it works for new users with no existing vs code config in their home folder, someone else should try building and launching this before merging.

CC: @sfabbro 