### PR TITLE
Cadc 12260 Added GPU stats for a session

### DIFF
--- a/deployment/k8s-config/kustomize/base/skaha/skaha-tomcat-deployment.yaml
+++ b/deployment/k8s-config/kustomize/base/skaha/skaha-tomcat-deployment.yaml
@@ -40,7 +40,7 @@ spec:
           value: "ivo://cadc.nrc.ca/gms?skaha-users"
         - name: skaha.adminsgroup
           value: "ivo://cadc.nrc.ca/gms?skaha-admins"
-        image: images.canfar.net/skaha-system/skaha:0.9.14
+        image: images.canfar.net/skaha-system/skaha:0.9.17
         imagePullPolicy: Always
         #imagePullPolicy: IfNotPresent
         name: skaha-tomcat

--- a/deployment/k8s-config/kustomize/base/skaha/skaha-tomcat-deployment.yaml
+++ b/deployment/k8s-config/kustomize/base/skaha/skaha-tomcat-deployment.yaml
@@ -40,7 +40,7 @@ spec:
           value: "ivo://cadc.nrc.ca/gms?skaha-users"
         - name: skaha.adminsgroup
           value: "ivo://cadc.nrc.ca/gms?skaha-admins"
-        image: images.canfar.net/skaha-system/skaha:0.9.17
+        image: images.canfar.net/skaha-system/skaha:0.9.19
         imagePullPolicy: Always
         #imagePullPolicy: IfNotPresent
         name: skaha-tomcat

--- a/deployment/k8s-config/kustomize/overlays/keel-dev/skaha/skaha-tomcat-deployment.yaml
+++ b/deployment/k8s-config/kustomize/overlays/keel-dev/skaha/skaha-tomcat-deployment.yaml
@@ -18,7 +18,7 @@ spec:
           value: "ivo://cadc.nrc.ca/gms?skaha-admins"
         - name: skaha.sessionexpiry
           value: "345600"
-        image: images-rc.canfar.net/skaha-system/skaha:0.9.14
+        image: images-rc.canfar.net/skaha-system/skaha:0.9.17
         resources:
           requests:
             memory: "4Gi"

--- a/deployment/k8s-config/kustomize/overlays/keel-dev/skaha/skaha-tomcat-deployment.yaml
+++ b/deployment/k8s-config/kustomize/overlays/keel-dev/skaha/skaha-tomcat-deployment.yaml
@@ -18,7 +18,7 @@ spec:
           value: "ivo://cadc.nrc.ca/gms?skaha-admins"
         - name: skaha.sessionexpiry
           value: "345600"
-        image: images-rc.canfar.net/skaha-system/skaha:0.9.17
+        image: images-rc.canfar.net/skaha-system/skaha:0.9.19
         resources:
           requests:
             memory: "4Gi"

--- a/skaha/VERSION
+++ b/skaha/VERSION
@@ -1,4 +1,4 @@
 ## deployable containers have a semantic and build tag
 # semantic version tag: major.minor
 # build version tag: timestamp
-TAGS="0.9.17 $(date -u +"%Y%m%dT%H%M%S")"
+TAGS="0.9.19 $(date -u +"%Y%m%dT%H%M%S")"

--- a/skaha/VERSION
+++ b/skaha/VERSION
@@ -1,4 +1,4 @@
 ## deployable containers have a semantic and build tag
 # semantic version tag: major.minor
 # build version tag: timestamp
-TAGS="0.9.14 $(date -u +"%Y%m%dT%H%M%S")"
+TAGS="0.9.17 $(date -u +"%Y%m%dT%H%M%S")"

--- a/skaha/src/main/java/org/opencadc/skaha/session/Session.java
+++ b/skaha/src/main/java/org/opencadc/skaha/session/Session.java
@@ -93,10 +93,10 @@ public class Session {
     private String requestedRAM;
     private String requestedCPUCores;
     private String requestedGPUCores;
-    private String cpuCoresInUse;
-    private String gpuMemoryUsage;
-    private String gpuUtilization;
     private String ramInUse;
+    private String gpuRAMInUse;
+    private String cpuCoresInUse;
+    private String gpuUtilization;
 
     public Session(String id, String userid, String image, String type, String status, String name, String startTime, String connectURL) {
         if (id == null) {
@@ -184,12 +184,12 @@ public class Session {
         this.gpuUtilization = util;
     }
 
-    public String getGPUMemoryUsage() {
-        return gpuMemoryUsage;
+    public String getGPURAMInUse() {
+        return gpuRAMInUse;
     }
 
-    public void setGPUMemoryUsage(String util) {
-        this.gpuMemoryUsage = util;
+    public void setGPURAMInUse(String util) {
+        this.gpuRAMInUse = util;
     }
 
     public String getRAMInUse() {

--- a/skaha/src/main/java/org/opencadc/skaha/session/Session.java
+++ b/skaha/src/main/java/org/opencadc/skaha/session/Session.java
@@ -94,6 +94,8 @@ public class Session {
     private String requestedCPUCores;
     private String requestedGPUCores;
     private String cpuCoresInUse;
+    private String gpuMemoryUsage;
+    private String gpuUtilization;
     private String ramInUse;
 
     public Session(String id, String userid, String image, String type, String status, String name, String startTime, String connectURL) {
@@ -172,6 +174,22 @@ public class Session {
 
     public void setCPUCoresInUse(String cores) {
         this.cpuCoresInUse = cores;
+    }
+
+    public String getGPUUtilization() {
+        return gpuUtilization;
+    }
+
+    public void setGPUUtilization(String util) {
+        this.gpuUtilization = util;
+    }
+
+    public String getGPUMemoryUsage() {
+        return gpuMemoryUsage;
+    }
+
+    public void setGPUMemoryUsage(String util) {
+        this.gpuMemoryUsage = util;
     }
 
     public String getRAMInUse() {

--- a/skaha/src/main/java/org/opencadc/skaha/session/SessionAction.java
+++ b/skaha/src/main/java/org/opencadc/skaha/session/SessionAction.java
@@ -467,10 +467,10 @@ public abstract class SessionAction extends SkahaAction {
                             List<String> sessionGPUUsageCMD = getSessionGPUUsageCMD(k8sNamespace, fullName);
                             String sessionGPUUsage = execute(sessionGPUUsageCMD.toArray(new String[0]));
                             List<String> gpuUsage = getGPUUsage(sessionGPUUsage);
-                            session.setGPUMemoryUsage(gpuUsage.get(0));
+                            session.setGPURAMInUse(gpuUsage.get(0));
                             session.setGPUUtilization(gpuUsage.get(1));
                         } else {
-                            session.setGPUMemoryUsage(NONE);
+                            session.setGPURAMInUse(NONE);
                             session.setGPUUtilization(NONE);
                         }
                     }
@@ -546,11 +546,13 @@ public abstract class SessionAction extends SkahaAction {
                     String[] segments = line.trim().split("\\|");
                     if (segments.length > 3) {
                         if (segments[3].contains("%")) {
-                            String mem = formatGPUMemoryUsage(segments[2].trim());
                             String util = segments[3].trim().split(" ")[0];
-                            usage.add(mem);
-                            usage.add(util);
-                            break;
+                            if (util.contains("%")) {
+                                String mem = formatGPUMemoryUsage(segments[2].trim());
+                                usage.add(mem);
+                                usage.add(util);
+                                break;
+                            }
                         }
                     }
                 }

--- a/skaha/src/main/java/org/opencadc/skaha/session/SessionAction.java
+++ b/skaha/src/main/java/org/opencadc/skaha/session/SessionAction.java
@@ -574,7 +574,7 @@ public abstract class SessionAction extends SkahaAction {
             customColumns = customColumns + 
             ",REQUESTEDRAM:.spec.containers[0].resources.requests.memory," +
             "REQUESTEDCPU:.spec.containers[0].resources.requests.cpu," +
-            "REQUESTEDGPU:.spec.containers[0].resources.requests.nvidia.com/gpu," +
+            "REQUESTEDGPU:.spec.containers[0].resources.requests.nvidia\\.com/gpu," +
             "FULLNAME:.metadata.name," +
             "UID:.metadata.ownerReferences[].uid"; 
         }


### PR DESCRIPTION
Current output looks like the following. Three key/values pairs have been added for the GPU stats.
```
% curl -E ~/.ssl/cadcproxy.pem  https://rc-uv.canfar.net/skaha/session
[
  {
    "id": "zcgim60c",
    "userid": "alinga",
    "image": "images-rc.canfar.net/skaha/desktop:1.0.3",
    "type": "desktop",
    "status": "Running",
    "name": "alinga-skaha-desktop",
    "startTime": "2023-02-22T00:48:30Z",
    "expiryTime": "2023-02-26T00:48:30Z",
    "connectURL": "https://rc-uv.canfar.net/session/desktop/zcgim60c/?password=zcgim60c&path=session/desktop/zcgim60c/",
    "requestedRAM": "1G",
    "requestedCPUCores": "0.25",
    "requestedGPUCores": "<none>",
    "ramInUse": "95M",
    "gpuRAMInUse": "<none>",
    "cpuCoresInUse": "0.001",
    "gpuUtilization": "<none>"
  },
  {
    "id": "pg0x4kr4",
    "userid": "alinga",
    "image": "images-rc.canfar.net/skaha/skaha-notebook:22.09-test",
    "type": "notebook",
    "status": "Running",
    "name": "alinga-skaha-notebook",
    "startTime": "2023-02-21T22:41:31Z",
    "expiryTime": "2023-02-25T22:41:31Z",
    "connectURL": "https://rc-uv.canfar.net/session/notebook/pg0x4kr4/lab/tree/arc/home/alinga?token=pg0x4kr4",
    "requestedRAM": "16G",
    "requestedCPUCores": "2",
    "requestedGPUCores": "1",
    "ramInUse": "67M",
    "gpuRAMInUse": "560M / 8192M",
    "cpuCoresInUse": "0.0",
    "gpuUtilization": "0%"
  }
]
```