### PR TITLE
CADC-11253: science platform changes to support postgres uws job persistence.

### DIFF
--- a/deployment/k8s-config/kustomize/base/arc/arc-tomcat-deployment.yaml
+++ b/deployment/k8s-config/kustomize/base/arc/arc-tomcat-deployment.yaml
@@ -24,7 +24,7 @@ spec:
                 operator: DoesNotExist
       containers:
       - name: arc-tomcat
-        image: images.canfar.net/skaha-system/cavern:0.4.5
+        image: images.canfar.net/skaha-system/cavern:0.4.6
         imagePullPolicy: Always
         resources:
           requests:

--- a/deployment/k8s-config/kustomize/base/arc/config/catalina.properties
+++ b/deployment/k8s-config/kustomize/base/arc/config/catalina.properties
@@ -4,3 +4,9 @@ tomcat.connector.proxyPort=443
 ca.nrc.cadc.auth.PrincipalExtractor.enableClientCertHeader=true
 ca.nrc.cadc.util.Log4jInit.messageOnly=true
 ca.nrc.cadc.auth.IdentityManager=ca.nrc.cadc.auth.ACIdentityManager
+
+# uws database connection pool
+org.opencadc.cavern.uws.maxActive=<maxActive>
+org.opencadc.cavern.uws.username=<username>
+org.opencadc.cavern.uws.password=<password>
+org.opencadc.cavern.uws.url=jdbc:postgresql://ad-uv-01.canfar.net:5432/arcdb

--- a/deployment/k8s-config/kustomize/overlays/keel-dev/arc/arc-tomcat-deployment.yaml
+++ b/deployment/k8s-config/kustomize/overlays/keel-dev/arc/arc-tomcat-deployment.yaml
@@ -7,7 +7,7 @@ spec:
     spec:
       containers:
       - name: arc-tomcat
-        image: images-rc.canfar.net/skaha-system/cavern:0.4.5
+        image: images-rc.canfar.net/skaha-system/cavern:0.4.6
       volumes:
       - name: cavern-ceph-volume
         cephfs:

--- a/deployment/k8s-config/kustomize/overlays/keel-dev/arc/config/catalina.properties
+++ b/deployment/k8s-config/kustomize/overlays/keel-dev/arc/config/catalina.properties
@@ -6,3 +6,10 @@ ca.nrc.cadc.reg.client.RegistryClient.host=rc-ws.cadc-ccda.hia-iha.nrc-cnrc.gc.c
 ca.nrc.cadc.util.Log4jInit.messageOnly=true
 ca.nrc.cadc.vos.server.vosUriBase=vos://cadc.nrc.ca~arc
 ca.nrc.cadc.auth.IdentityManager=ca.nrc.cadc.auth.ACIdentityManager
+
+
+# uws database connection pool
+org.opencadc.cavern.uws.maxActive=<maxActive>
+org.opencadc.cavern.uws.username=<username>
+org.opencadc.cavern.uws.password=<password>
+org.opencadc.cavern.uws.url=jdbc:postgresql://ad-uv-01.canfar.net:5432/arcdb


### PR DESCRIPTION
catalina.properties, up cavern image version to 0.4.6, to use code supporting postgres uws job persistence.