### PR TITLE
Cadc 12493 Updated skaha to support an image with multiple types/labels

### DIFF
--- a/deployment/k8s-config/kustomize/base/skaha-workload/config/build-menu.sh
+++ b/deployment/k8s-config/kustomize/base/skaha-workload/config/build-menu.sh
@@ -150,7 +150,7 @@ build_menu_item () {
 echo "[skaha] Start building menu."
 init
 create_merged_applications_menu
-apps=$(curl -s -k -E ~/.ssl/cadcproxy.pem https://${HOST}/skaha/image?type=desktop-app | grep '"id"')
+apps=$(curl -s -k -E ~/.ssl/cadcproxy.pem https://${HOST}/skaha/v0/image?type=desktop-app | grep '"id"')
 if [[ ${apps} == *"id"* ]]; then
   project_array=()
   while IFS= read -r line

--- a/deployment/k8s-config/kustomize/base/skaha/skaha-tomcat-deployment.yaml
+++ b/deployment/k8s-config/kustomize/base/skaha/skaha-tomcat-deployment.yaml
@@ -40,7 +40,7 @@ spec:
           value: "ivo://cadc.nrc.ca/gms?skaha-users"
         - name: skaha.adminsgroup
           value: "ivo://cadc.nrc.ca/gms?skaha-admins"
-        image: images.canfar.net/skaha-system/skaha:0.9.22
+        image: images.canfar.net/skaha-system/skaha:0.10.0
         imagePullPolicy: Always
         #imagePullPolicy: IfNotPresent
         name: skaha-tomcat

--- a/deployment/k8s-config/kustomize/base/skaha/skaha-tomcat-deployment.yaml
+++ b/deployment/k8s-config/kustomize/base/skaha/skaha-tomcat-deployment.yaml
@@ -40,7 +40,7 @@ spec:
           value: "ivo://cadc.nrc.ca/gms?skaha-users"
         - name: skaha.adminsgroup
           value: "ivo://cadc.nrc.ca/gms?skaha-admins"
-        image: images.canfar.net/skaha-system/skaha:0.9.21
+        image: images.canfar.net/skaha-system/skaha:0.9.22
         imagePullPolicy: Always
         #imagePullPolicy: IfNotPresent
         name: skaha-tomcat

--- a/deployment/k8s-config/kustomize/overlays/keel-dev/skaha/skaha-tomcat-deployment.yaml
+++ b/deployment/k8s-config/kustomize/overlays/keel-dev/skaha/skaha-tomcat-deployment.yaml
@@ -19,7 +19,7 @@ spec:
           value: "ivo://cadc.nrc.ca/gms?skaha-admins"
         - name: skaha.sessionexpiry
           value: "345600"
-        image: images-rc.canfar.net/skaha-system/skaha:0.9.20
+        image: images-rc.canfar.net/skaha-system/skaha:0.9.22
         resources:
           requests:
             memory: "4Gi"

--- a/deployment/k8s-config/kustomize/overlays/keel-dev/skaha/skaha-tomcat-deployment.yaml
+++ b/deployment/k8s-config/kustomize/overlays/keel-dev/skaha/skaha-tomcat-deployment.yaml
@@ -19,7 +19,7 @@ spec:
           value: "ivo://cadc.nrc.ca/gms?skaha-admins"
         - name: skaha.sessionexpiry
           value: "345600"
-        image: images-rc.canfar.net/skaha-system/skaha:0.9.22
+        image: images-rc.canfar.net/skaha-system/skaha:0.10.0
         resources:
           requests:
             memory: "4Gi"

--- a/skaha/VERSION
+++ b/skaha/VERSION
@@ -1,4 +1,4 @@
 ## deployable containers have a semantic and build tag
 # semantic version tag: major.minor
 # build version tag: timestamp
-TAGS="0.9.22 $(date -u +"%Y%m%dT%H%M%S")"
+TAGS="0.10.0 $(date -u +"%Y%m%dT%H%M%S")"

--- a/skaha/VERSION
+++ b/skaha/VERSION
@@ -1,4 +1,4 @@
 ## deployable containers have a semantic and build tag
 # semantic version tag: major.minor
 # build version tag: timestamp
-TAGS="0.9.21 $(date -u +"%Y%m%dT%H%M%S")"
+TAGS="0.9.22 $(date -u +"%Y%m%dT%H%M%S")"

--- a/skaha/src/main/java/org/opencadc/skaha/SkahaAction.java
+++ b/skaha/src/main/java/org/opencadc/skaha/SkahaAction.java
@@ -295,10 +295,7 @@ public abstract class SkahaAction extends RestAction {
                             JSONArray labels = jArtifact.getJSONArray("labels");
                             Set<String> types = getTypesFromLabels(labels);
                             if (types.size() > 0) {
-                                // TODO: fix the cardinality of types to image.
-                                // ie--A running image has 1 type, but an image can have multiple
-                                // supported types before being launched.
-                                return new Image(imageID, types.iterator().next(), digest);
+                                return new Image(imageID, types, digest);
                             }
                         }
                     }

--- a/skaha/src/main/java/org/opencadc/skaha/image/GetAction.java
+++ b/skaha/src/main/java/org/opencadc/skaha/image/GetAction.java
@@ -263,14 +263,7 @@ public class GetAction extends SkahaAction {
                             String tag = jTag.getString("name");
                             String imageID = harborHost + "/" + rName + ":" + tag;
                             Image image = null;
-                            if (typeFilter == null) {
-                                // TODO: Sort out the cardinality problem with images types.
-                                // Images can have multiple types (labels), but running images
-                                // have a single type.
-                                image = new Image(imageID, types.iterator().next(), digest);
-                            } else {
-                                image = new Image(imageID, typeFilter, digest);
-                            }
+                            image = new Image(imageID, types, digest);
                             // collect this image
                             images.add(image);
                             log.debug("Added image: " + imageID);

--- a/skaha/src/main/java/org/opencadc/skaha/image/GetAction.java
+++ b/skaha/src/main/java/org/opencadc/skaha/image/GetAction.java
@@ -258,7 +258,6 @@ public class GetAction extends SkahaAction {
                     if (!jArtifact.isNull("tags")) {
                         JSONArray tags = jArtifact.getJSONArray("tags");
                         for (int j=0; j<tags.length(); j++) {
-                            long perTagStart = System.currentTimeMillis();
                             JSONObject jTag = tags.getJSONObject(j);
                             String tag = jTag.getString("name");
                             String imageID = harborHost + "/" + rName + ":" + tag;

--- a/skaha/src/main/java/org/opencadc/skaha/image/Image.java
+++ b/skaha/src/main/java/org/opencadc/skaha/image/Image.java
@@ -116,6 +116,10 @@ public class Image {
     }
 
     private boolean hasSameTypes(Set<String> inputTypes) {
+        if (inputTypes == null || inputTypes.isEmpty()) {
+            return false;
+        }
+
         for (String iType : inputTypes) {
             boolean found = false;
             for (String type : this.types) {

--- a/skaha/src/main/java/org/opencadc/skaha/image/Image.java
+++ b/skaha/src/main/java/org/opencadc/skaha/image/Image.java
@@ -66,6 +66,9 @@
  */
 package org.opencadc.skaha.image;
 
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * @author majorb
  *
@@ -73,21 +76,21 @@ package org.opencadc.skaha.image;
 public class Image {
     
     private String id;
-    private String type;
+    private Set<String> types;
     private String digest;
     
-    public Image(String id, String type, String digest) {
+    public Image(String id, Set<String> types, String digest) {
         if (id == null) {
             throw new IllegalArgumentException("id requried");
         }
-        if (type == null) {
+        if (types == null || types.isEmpty()) {
             throw new IllegalArgumentException("type required");
         }
         if (digest == null) {
             throw new IllegalArgumentException("digest requried");
         }
         this.id = id;
-        this.type = type;
+        this.types = new HashSet<String>(types);
         this.digest = digest;
     }
 
@@ -95,8 +98,8 @@ public class Image {
         return id;
     }
 
-    public String getType() {
-        return type;
+    public Set<String> getTypes() {
+        return types;
     }
 
     public String getDigest() {
@@ -107,9 +110,26 @@ public class Image {
     public boolean equals(Object o) {
         if (o instanceof Image) {
             Image i = (Image) o;
-            return i.id.equals(this.id) && i.digest.equals(this.digest) && i.type.equals(this.type);
+            return i.id.equals(this.id) && i.digest.equals(this.digest) && hasSameTypes(i.types);
         }
         return false;
     }
 
+    private boolean hasSameTypes(Set<String> inputTypes) {
+        for (String iType : inputTypes) {
+            boolean found = false;
+            for (String type : this.types) {
+                if (type.equals(iType)) {
+                   found = true;
+                   break;
+                }
+            }
+            
+            if (!found) {
+                return false;
+            }
+        }
+        
+        return true;
+    }
 }

--- a/skaha/src/main/java/org/opencadc/skaha/session/PostAction.java
+++ b/skaha/src/main/java/org/opencadc/skaha/session/PostAction.java
@@ -388,10 +388,15 @@ public class PostAction extends SessionAction {
                 if (image == null) {
                     throw new ResourceNotFoundException("image not found or not labelled: " + imageID);
                 }
-                if (type != null && !image.getTypes().contains(type)) {
-                    throw new IllegalArgumentException("image/type mismatch: " + imageID + "/" + type);
+                if (type == null) {
+                    return image.getTypes().iterator().next();
+                } else {
+                    if (image.getTypes().contains(type)) {
+                        return type;
+                    } else {
+                        throw new IllegalArgumentException("image/type mismatch: " + imageID + "/" + type);
+                    }
                 }
-                return type;
             }
         }
                 

--- a/skaha/src/main/java/org/opencadc/skaha/session/PostAction.java
+++ b/skaha/src/main/java/org/opencadc/skaha/session/PostAction.java
@@ -388,10 +388,10 @@ public class PostAction extends SessionAction {
                 if (image == null) {
                     throw new ResourceNotFoundException("image not found or not labelled: " + imageID);
                 }
-                if (type != null && !type.equals(image.getType())) {
+                if (type != null && !image.getTypes().contains(type)) {
                     throw new IllegalArgumentException("image/type mismatch: " + imageID + "/" + type);
                 }
-                return image.getType();
+                return type;
             }
         }
                 

--- a/skaha/src/main/webapp/WEB-INF/web.xml
+++ b/skaha/src/main/webapp/WEB-INF/web.xml
@@ -118,17 +118,17 @@
     
     <servlet-mapping>
         <servlet-name>SessionServlet</servlet-name>
-        <url-pattern>/session/*</url-pattern>
+        <url-pattern>/v0/session/*</url-pattern>
     </servlet-mapping>
     
     <servlet-mapping>
         <servlet-name>ContextServlet</servlet-name>
-        <url-pattern>/context/*</url-pattern>
+        <url-pattern>/v0/context/*</url-pattern>
     </servlet-mapping>
     
     <servlet-mapping>
         <servlet-name>ImageServlet</servlet-name>
-        <url-pattern>/image/*</url-pattern>
+        <url-pattern>/v0/image/*</url-pattern>
     </servlet-mapping>
         
     <servlet-mapping>

--- a/skaha/src/main/webapp/capabilities.xml
+++ b/skaha/src/main/webapp/capabilities.xml
@@ -24,15 +24,15 @@
 
   <capability standardID="vos://cadc.nrc.ca~vospace/CADC/std/Proc#sessions-1.0">
     <interface xsi:type="vs:ParamHTTP" role="std" version="1.0">
-      <accessURL use="base">https://replace.me.com/skaha</accessURL>
+        <accessURL use="base">https://replace.me.com/skaha/v0</accessURL>
       <securityMethod standardID="ivo://ivoa.net/sso#cookie"/>
     </interface>
     <interface xsi:type="vs:ParamHTTP" role="std" version="1.0">
-      <accessURL use="base">https://replace.me.com/skaha</accessURL>
+        <accessURL use="base">https://replace.me.com/skaha/v0</accessURL>
       <securityMethod standardID="ivo://ivoa.net/sso#tls-with-certificate"/>
     </interface>
     <interface xsi:type="vs:ParamHTTP" role="std" version="1.0">
-      <accessURL use="base">https://replace.me.com/skaha</accessURL>
+        <accessURL use="base">https://replace.me.com/skaha/v0</accessURL>
       <securityMethod standardID="ivo://ivoa.net/sso#token"/>
     </interface>
   </capability>

--- a/skaha/src/main/webapp/service.yaml
+++ b/skaha/src/main/webapp/service.yaml
@@ -1,6 +1,6 @@
 swagger: '2.0'
 info:
-  version: 0.3
+  version: 0.4
   title: skaha
   description: |
     skaha API Documentation.  This API allows authorized users to create and interact with desktop (NoVNC), CARTA Visualization, and Jupyter Notebook sessions in the skaha processing environment.  Desktop apps can also be launched and attached to skaha desktop sessions through this API.<br/><br/>Clients may authenticate to this service by:<br/>1.  Providing a bearer token in the Authorization header.<br/>2.  Using a client certificate.<br/>3.  Using a browser cookie from CADC Login.<br/><br/>The main skaha github page with documentation and source code is here:  https://github.com/opencadc/science-platform<br/><br/>Documentation on using skaha can be found here:  https://github.com/opencadc/science-platform/tree/master/doc
@@ -8,7 +8,7 @@ schemes:
   - https
 basePath: /skaha
 paths:
-  /session:
+  /v0/session:
     get:
       description: |
         List the sessions for the calling user, returned as a JSON array.  Session attributes include:<br/><br/>Session ID<br/>User ID<br/>Image<br/>Type<br/>Status<br/>Name<br/>StartTime<br/>Connect URL<br/><br/>Valid types are 'desktop', 'carta', 'notebook', and 'headless'.
@@ -117,7 +117,7 @@ paths:
           description: Service busy
         default:
           description: Unexpected error
-  /session/{sessionID}:
+  /v0/session/{sessionID}:
     get:
       description: |
         Get the session identified by sessionID as a JSON object.
@@ -202,7 +202,7 @@ paths:
           description: Service busy
         default:
           description: Unexpected error
-  /session/{sessionID}/app:
+  /v0/session/{sessionID}/app:
     post:
       description: |
         Attach a desktop-app to the session identified by sessionID.  This only applies to sessions of type 'desktop'.
@@ -232,7 +232,7 @@ paths:
           description: Service busy
         default:
           description: Unexpected error
-  /image:
+  /v0/image:
     get:
       description: |
         List the images available for launching to the calling user, returned as a JSON array.  Image attributes include:<br/><br/>Image ID<br/>Image Type<br/>Digest (checksum)
@@ -257,7 +257,7 @@ paths:
         type: string
         description: Only show images of this type (desktop, notebook, or carta)
         required: false
-  /context:
+  /v0/context:
     get:
       description: |
         List the CPU cores and Random Access Memory available for launching to the calling user, returned as JSON objects.  The default values for both cores and RAM are also returned.

--- a/skaha/src/main/webapp/service.yaml
+++ b/skaha/src/main/webapp/service.yaml
@@ -1,6 +1,6 @@
 swagger: '2.0'
 info:
-  version: 0.4
+  version: 0.10.0
   title: skaha
   description: |
     skaha API Documentation.  This API allows authorized users to create and interact with desktop (NoVNC), CARTA Visualization, and Jupyter Notebook sessions in the skaha processing environment.  Desktop apps can also be launched and attached to skaha desktop sessions through this API.<br/><br/>Clients may authenticate to this service by:<br/>1.  Providing a bearer token in the Authorization header.<br/>2.  Using a client certificate.<br/>3.  Using a browser cookie from CADC Login.<br/><br/>The main skaha github page with documentation and source code is here:  https://github.com/opencadc/science-platform<br/><br/>Documentation on using skaha can be found here:  https://github.com/opencadc/science-platform/tree/master/doc

--- a/skaha/src/test/java/org/opencadc/skaha/image/GetImagesTests.java
+++ b/skaha/src/test/java/org/opencadc/skaha/image/GetImagesTests.java
@@ -71,7 +71,9 @@ import ca.nrc.cadc.util.Log4jInit;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
@@ -170,7 +172,9 @@ public class GetImagesTests {
             String json = gson.toJson(images);
             log.info(json);
             Assert.assertEquals("image count",  5, images.size());
-            Image test = new Image("test/petuan/new-earth-snap:0.1.1", "notebook",
+            Set<String> types = new HashSet<String>();
+            types.add("notebook");
+            Image test = new Image("test/petuan/new-earth-snap:0.1.1", types,
                 "sha256:439cadced5731d0946018fa3e2371444309c7cb8b6fc762c8f96ef915fc49ae4");
             Assert.assertTrue("exists", images.contains(test));
             


### PR DESCRIPTION
Here’s an excerpt of the output from the following curl command to list the images. The output shows images with more than one type/label.
curl -v -E ~/.ssl/cadcproxy.pem https://rc-uv.canfar.net/skaha/image
…
  {
    "id": "images.canfar.net/uvickbos/pycharm:0.1",
    "types": [
      "headless",
      "desktop-app"
    ],
    "digest": "sha256:203dde66cb2a4d3c4084c4439ae15499f0996961f203d6c0a29c8a65e0421572"
  },
  {
    "id": "images.canfar.net/uvickbos/swarp:0.1",
    "types": [
      "headless",
      "desktop-app"
    ],
    "digest": "sha256:af919892a3ce3b46729f5fe5815a643a30298da39f03a2086620752c78b1b880"
  },
  {
    "id": "images.canfar.net/uvickbos/iraf:0.2",
    "types": [
      "desktop-app"
    ],
    "digest": "sha256:09595ea5b2212f2438232835aafd126efa30232629e81d49af02fe96d64ff644"
  },
  {
    "id": "images.canfar.net/uvickbos/aram:0.1",
    "types": [
      "notebook"
    ],
    "digest": "sha256:1593dea69567b0a53337713db68246b3f1d9cf94147cdfa8d418eb0b8cf7a7c8"
  },