### PR TITLE
CADC-12838 Added missing gpu limit spec in launch-contributed.yaml.

### DIFF
--- a/deployment/k8s-config/kustomize/overlays/keel-dev/skaha/config/launch-contributed.yaml
+++ b/deployment/k8s-config/kustomize/overlays/keel-dev/skaha/config/launch-contributed.yaml
@@ -65,6 +65,7 @@ spec:
           limits:
             memory: "${software.limits.ram}"
             cpu: "${software.limits.cores}"
+            nvidia.com/gpu: "${software.limits.gpus}"
             ephemeral-storage: "200Gi"
         ports:
         - containerPort: 5000


### PR DESCRIPTION
For more details, please refer to the "Comments" section in the [story](https://cadc-ccda.atlassian.net/browse/CADC-12838).