### PR TITLE
fix: desktop-template start-software typo in get_status template function

### DIFF
--- a/deployment/helm/skaha/desktop-template/start-software-sh.template
+++ b/deployment/helm/skaha/desktop-template/start-software-sh.template
@@ -118,7 +118,7 @@ get_status() {
     local n=0
     sleep 1
     if [ -e "${HOME}/.token/Bearer" ]; then
-        curl_out=`curl -s -L -k --header "Authorization: Bearer ${TOKEN}"https://(HOST)/skaha/${SKAHA_API_VERSION}/session/${VNC_PW}/app/$1`
+        curl_out=`curl -s -L -k --header "Authorization: Bearer ${TOKEN}" https://(HOST)/skaha/${SKAHA_API_VERSION}/session/${VNC_PW}/app/$1`
     else
         curl_out=`curl -s -L -k -E ${HOME}/.ssl/cadcproxy.pem https://(HOST)/skaha/${SKAHA_API_VERSION}/session/${VNC_PW}/app/$1`
     fi


### PR DESCRIPTION
Very minor fix that allows me to launch terminal based sessions in the desktop sessions.