### PR TITLE
Add registryURL to cavern values.yaml

### DIFF
--- a/deployment/helm/README.md
+++ b/deployment/helm/README.md
@@ -411,6 +411,9 @@ deployment:
     # How cavern identifies itself.
     resourceID: "ivo://example.org/cavern"
 
+    # Set the Registry URL pointing to the desired registry
+    registryURL: "https://registry.example.org/reg"
+
     # How to find the POSIX Mapper API.  URI (ivo://) or URL (https://).
     posixMapperResourceID: "ivo://example.org/posix-mapper"
 

--- a/deployment/helm/cavern/values.yaml
+++ b/deployment/helm/cavern/values.yaml
@@ -17,6 +17,9 @@ deployment:
     # How cavern identifies itself.
     resourceID: "ivo://example.org/cavern"
 
+    # Set the Registry URL pointing to the desired registry
+    registryURL: https://spsrc27.iaa.csic.es/reg
+
     # The Resource ID of the Service that contains the Posix Mapping information
     posixMapperResourceID: "ivo://opencadc.org/posix-mapper"
 


### PR DESCRIPTION
Cavern: Adds .Values.deployment.cavern.registryURL in the default values.yaml

This parameter doesn't seem to be optional, so added it to the values.yaml. If this change doesn't make sense though, feel free to ignore this PR :) I just thought it might help since I ran into issues at first by not setting it.

I wasn't sure which default to set, but since there were already some default SKA values, I've set the default to be the prototype registry as well.