### PR TITLE
Cadc 12969 Added headless-users group membership check before spawning a new headless session

### DIFF
--- a/deployment/k8s-config/kustomize/base/skaha/skaha-tomcat-deployment.yaml
+++ b/deployment/k8s-config/kustomize/base/skaha/skaha-tomcat-deployment.yaml
@@ -41,7 +41,9 @@ spec:
         - name: skaha.usersgroup
           value: "ivo://cadc.nrc.ca/gms?skaha-users"
         - name: skaha.headlessgroup
-          value: "ivo://cadc.nrc.ca/gms?skaha-headless-users"
+          # TODO: change back to the correct headless group when ready
+          # value: "ivo://cadc.nrc.ca/gms?skaha-headless-users"
+          value: "ivo://cadc.nrc.ca/gms?skaha-users"
         - name: skaha.adminsgroup
           value: "ivo://cadc.nrc.ca/gms?skaha-admins"
         image: images.canfar.net/skaha-system/skaha:0.12.4

--- a/deployment/k8s-config/kustomize/base/skaha/skaha-tomcat-deployment.yaml
+++ b/deployment/k8s-config/kustomize/base/skaha/skaha-tomcat-deployment.yaml
@@ -44,7 +44,7 @@ spec:
           value: "ivo://cadc.nrc.ca/gms?skaha-headless-users"
         - name: skaha.adminsgroup
           value: "ivo://cadc.nrc.ca/gms?skaha-admins"
-        image: images.canfar.net/skaha-system/skaha:0.12.3
+        image: images.canfar.net/skaha-system/skaha:0.12.4
         imagePullPolicy: Always
         #imagePullPolicy: IfNotPresent
         name: skaha-tomcat

--- a/deployment/k8s-config/kustomize/base/skaha/skaha-tomcat-deployment.yaml
+++ b/deployment/k8s-config/kustomize/base/skaha/skaha-tomcat-deployment.yaml
@@ -40,6 +40,8 @@ spec:
           value: "images.canfar.net"
         - name: skaha.usersgroup
           value: "ivo://cadc.nrc.ca/gms?skaha-users"
+        - name: skaha.headlessgroup
+          value: "ivo://cadc.nrc.ca/gms?skaha-headless-users"
         - name: skaha.adminsgroup
           value: "ivo://cadc.nrc.ca/gms?skaha-admins"
         image: images.canfar.net/skaha-system/skaha:0.12.3

--- a/deployment/k8s-config/kustomize/overlays/keel-dev/skaha/skaha-tomcat-deployment.yaml
+++ b/deployment/k8s-config/kustomize/overlays/keel-dev/skaha/skaha-tomcat-deployment.yaml
@@ -23,7 +23,7 @@ spec:
           value: "345600"
         - name: skaha.defaultquotagb
           value: "10"
-        image: images-rc.canfar.net/skaha-system/skaha:0.12.3
+        image: images-rc.canfar.net/skaha-system/skaha:0.12.4
         resources:
           requests:
             memory: "4Gi"

--- a/deployment/k8s-config/kustomize/overlays/keel-dev/skaha/skaha-tomcat-deployment.yaml
+++ b/deployment/k8s-config/kustomize/overlays/keel-dev/skaha/skaha-tomcat-deployment.yaml
@@ -16,7 +16,9 @@ spec:
         - name: skaha.usersgroup
           value: "ivo://cadc.nrc.ca/gms?skaha-users"
         - name: skaha.headlessgroup
-          value: "ivo://cadc.nrc.ca/gms?skaha-headless-users"
+          # TODO: change back to the correct headless group when ready
+          # value: "ivo://cadc.nrc.ca/gms?skaha-headless-users"
+          value: "ivo://cadc.nrc.ca/gms?skaha-users"
         - name: skaha.adminsgroup
           value: "ivo://cadc.nrc.ca/gms?skaha-admins"
         - name: skaha.sessionexpiry

--- a/deployment/k8s-config/kustomize/overlays/keel-dev/skaha/skaha-tomcat-deployment.yaml
+++ b/deployment/k8s-config/kustomize/overlays/keel-dev/skaha/skaha-tomcat-deployment.yaml
@@ -15,6 +15,8 @@ spec:
           value: "images-rc.canfar.net"
         - name: skaha.usersgroup
           value: "ivo://cadc.nrc.ca/gms?skaha-users"
+        - name: skaha.headlessgroup
+          value: "ivo://cadc.nrc.ca/gms?skaha-headless-users"
         - name: skaha.adminsgroup
           value: "ivo://cadc.nrc.ca/gms?skaha-admins"
         - name: skaha.sessionexpiry

--- a/skaha/VERSION
+++ b/skaha/VERSION
@@ -1,4 +1,4 @@
 ## deployable containers have a semantic and build tag
 # semantic version tag: major.minor
 # build version tag: timestamp
-TAGS="0.12.3 $(date -u +"%Y%m%dT%H%M%S")"
+TAGS="0.12.4 $(date -u +"%Y%m%dT%H%M%S")"

--- a/skaha/src/main/java/org/opencadc/skaha/SkahaAction.java
+++ b/skaha/src/main/java/org/opencadc/skaha/SkahaAction.java
@@ -117,11 +117,13 @@ public abstract class SkahaAction extends RestAction {
 
     protected String userID;
     protected boolean adminUser = false;
+    protected boolean headlessUser = false;
     protected String server;
     protected String homedir;
     protected String scratchdir;
     public List<String> harborHosts = new ArrayList<>();
     protected String skahaUsersGroup;
+    protected String skahaHeadlessGroup;
     protected String skahaAdminsGroup;
     protected int maxUserSessions;
 
@@ -136,6 +138,7 @@ public abstract class SkahaAction extends RestAction {
             harborHosts = Arrays.asList(harborHostList.split(" "));
         }
         skahaUsersGroup = System.getenv("skaha.usersgroup");
+        skahaHeadlessGroup = System.getenv("skaha.headlessgroup");
         skahaAdminsGroup = System.getenv("skaha.adminsgroup");
         String maxUsersSessionsString = System.getenv("skaha.maxusersessions");
         if (maxUsersSessionsString == null) {
@@ -149,6 +152,7 @@ public abstract class SkahaAction extends RestAction {
         log.debug("skaha.scratchdir=" + scratchdir);
         log.debug("skaha.harborHosts=" + harborHostList);
         log.debug("skaha.usersgroup=" + skahaUsersGroup);
+        log.debug("skaha.headlessgroup=" + skahaHeadlessGroup);
         log.debug("skaha.adminsgroup=" + skahaAdminsGroup);
         log.debug("skaha.maxusersessions=" + maxUserSessions);
     }


### PR DESCRIPTION
In case not all headless users have been added to the headless-user groups, for now the headless-users group is set to the skaha-users group to avoid having problems during the Holidays.