### PR TITLE
cavern-tomcat-deployment: deduplicate securityContext key

### DIFF
--- a/deployment/helm/cavern/templates/cavern-tomcat-deployment.yaml
+++ b/deployment/helm/cavern/templates/cavern-tomcat-deployment.yaml
@@ -20,6 +20,7 @@ spec:
       {{ $cavernTLD := printf "%s/%s" .dataDir .subPath }}
       securityContext:
         fsGroup: {{ .rootOwner.gid }}
+        runAsUser: 0
       initContainers:
       - name: init-{{ $.Release.Name }}-fs
         image: busybox
@@ -58,8 +59,6 @@ spec:
         {{- with .Values.deployment.cavern.extraVolumeMounts }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
-      securityContext:
-        runAsUser: 0
       priorityClassName: uber-user-preempt-high
       serviceAccountName: skaha
       volumes:


### PR DESCRIPTION
The securityContext key was duplicated, and while a `helm install` and `helm upgrade` don't seem to care, our flux helm controller seems to want to parse/validate the yaml and gets upset about the duplicate key not being valid yaml.