### PR TITLE
Overwrite Chart with Traefik ports set to null.

### DIFF
--- a/deployment/helm/base/Chart.yaml
+++ b/deployment/helm/base/Chart.yaml
@@ -13,7 +13,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.2
+version: 0.3.3
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.

--- a/deployment/helm/skaha/launch-scripts/start-jupyterlab.sh
+++ b/deployment/helm/skaha/launch-scripts/start-jupyterlab.sh
@@ -9,9 +9,6 @@ cd ${HOME}
 mkdir -p ${HOME}/.token
 
 jupyter lab \
-	--NotebookApp.base_url=session/notebook/"$1" \
-	--NotebookApp.notebook_dir=/ \
-	--NotebookApp.allow_origin="*" \
 	--ServerApp.ip=0.0.0.0 \
 	--ServerApp.port=8888 \
 	--no-browser \

--- a/deployment/helm/skaha/skaha-config/launch-notebook.yaml
+++ b/deployment/helm/skaha/skaha-config/launch-notebook.yaml
@@ -59,11 +59,17 @@ spec:
         - name: JUPYTER_TOKEN
           value: "${skaha.sessionid}"
         - name: JUPYTER_CONFIG_DIR
-          value: "${SKAHA_TLD}/home/${skaha.userid}"
+          value: "${SKAHA_TLD}/home/${skaha.userid}/.jupyter/"
+        - name: JUPYTER_DATA_DIR
+          value: "${SKAHA_TLD}/home/${skaha.userid}/.local/share/jupyter/"
+        - name: JUPYTER_RUNTIME_DIR
+          value: "${SKAHA_TLD}/home/${skaha.userid}/.local/share/jupyter/runtime/"
         - name: JUPYTER_PATH
-          value: "${SKAHA_TLD}/home/${skaha.userid}"
-#        - name: JUPYTERLAB_DIR
-#          value: "${SKAHA_TLD}/home/${skaha.userid}/skaha-lab"
+          value: "${SKAHA_TLD}/home/${skaha.userid}/.jupyter/"
+        - name: JUPYTERLAB_WORKSPACES_DIR
+          value: "${SKAHA_TLD}/home/${skaha.userid}/.jupyter/lab/workspaces/"
+        - name: JUPYTERLAB_SETTINGS_DIR
+          value: "${SKAHA_TLD}/home/${skaha.userid}/.jupyter/lab/user-settings/"
         - name: NB_USER
           value: "${skaha.userid}"
         - name: NB_UID

--- a/deployment/k8s-config/kustomize/base/arc/arc-tomcat-deployment.yaml
+++ b/deployment/k8s-config/kustomize/base/arc/arc-tomcat-deployment.yaml
@@ -24,7 +24,7 @@ spec:
                 operator: DoesNotExist
       containers:
       - name: arc-tomcat
-        image: images.opencadc.org/platform/cavern:0.7.3
+        image: images.opencadc.org/platform/cavern:0.7.4
         imagePullPolicy: Always
         resources:
           requests:

--- a/deployment/k8s-config/kustomize/overlays/keel-dev/arc/arc-tomcat-deployment.yaml
+++ b/deployment/k8s-config/kustomize/overlays/keel-dev/arc/arc-tomcat-deployment.yaml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: arc-tomcat
-        image: images.opencadc.org/platform/cavern:0.7.3
+        image: images.opencadc.org/platform/cavern:0.7.4
       volumes:
       - name: cavern-ceph-volume
         cephfs:


### PR DESCRIPTION
The current base has `ports` set to `null` for some reason.  Fixing.