### PR TITLE
Cavern quota

### DIFF
--- a/deployment/helm/README.md
+++ b/deployment/helm/README.md
@@ -417,13 +417,13 @@ Please see the [minimum configuration](./cavern/README.md).  A quick look is:
 deployment:
   hostname: example.org  # Change this!
   cavern:
-    # How cavern identifies itself.
+    # How cavern identifies itself.  Required.
     resourceID: "ivo://example.org/cavern"
 
-    # Set the Registry URL pointing to the desired registry
+    # Set the Registry URL pointing to the desired registry.  Required
     registryURL: "https://registry.example.org/reg"
 
-    # How to find the POSIX Mapper API.  URI (ivo://) or URL (https://).
+    # How to find the POSIX Mapper API.  URI (ivo://) or URL (https://).  Required.
     posixMapperResourceID: "ivo://example.org/posix-mapper"
 
     filesystem:
@@ -458,27 +458,43 @@ deployment:
 
     # The endpoint to serve this from.  Defaults to /cavern.  If the applicationName is changed, then this should match.
     # Don't forget to update your registry entries!
+    #
     # endpoint: "/cavern"
 
     # Optionally set the DEBUG port.
+    #
+    # Example:
     # extraEnv:
     # - name: CATALINA_OPTS
     #   value: "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0.0.0.0:5555"
     # - name: JAVA_OPTS
     #   value: "-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=0.0.0.0:5555"
+    #
+    # extraEnv:
 
     # Optionally mount a custom CA certificate
+    # Example:
     # extraVolumeMounts:
     # - mountPath: "/config/cacerts"
     #   name: cacert-volume
+    # 
+    # extraVolumeMounts:
 
     # Create the CA certificate volume to be mounted in extraVolumeMounts
+    # Example:
     # extraVolumes:
     # - name: cacert-volume
     #   secret:
     #     defaultMode: 420
     #     secretName: skaha-cacert-secret
+    #
+    # extraVolumes:
 
+    # Other data to be included in the main ConfigMap of this deployment.
+    # Of note, files that end in .key are special and base64 decoded.
+    # 
+    # extraConfigData:
+    
     # Resources provided to the Skaha service.
     resources:
       requests:
@@ -487,6 +503,18 @@ deployment:
       limits:
         memory: "1Gi"
         cpu: "500m"
+
+  # Specify extra hostnames that will be added to the Pod's /etc/hosts file.  Note that this is in the
+  # deployment object, not the cavern one.
+  #
+  # These entries get added as hostAliases entries to the Deployment.
+  #
+  # Example:
+  # extraHosts:
+  #   - ip: 127.3.34.5
+  #     hostname: myhost.example.org
+  #
+  # extraHosts: []
 
 # secrets:
   # Uncomment to enable local or self-signed CA certificates for your domain to be trusted.

--- a/deployment/helm/cavern/CHANGELOG.md
+++ b/deployment/helm/cavern/CHANGELOG.md
@@ -1,4 +1,10 @@
-# CHANGELOG for Cavern User Storage (Chart 0.3.0)
+# CHANGELOG for Cavern User Storage (Chart 0.3.8)
+
+## 2024.05.27 (0.3.8)
+- Fix for Quota reporting
+- Fix for folder size reporting
+- Added `extraHosts` mapping for manual DNS entries
+- Added `extraConfigData` to add to the Cavern `ConfigMap`.
 
 ## 2024.03.12 (0.3.0)
 - Bug fixes in allocation

--- a/deployment/helm/cavern/CHANGELOG.md
+++ b/deployment/helm/cavern/CHANGELOG.md
@@ -1,6 +1,7 @@
-# CHANGELOG for Cavern User Storage (Chart 0.3.8)
+# CHANGELOG for Cavern User Storage (Chart 0.4.0)
 
-## 2024.05.27 (0.3.8)
+## 2024.05.27 (0.4.0)
+- Enforcing some values to be set by the deployer.
 - Fix for Quota reporting
 - Fix for folder size reporting
 - Added `extraHosts` mapping for manual DNS entries

--- a/deployment/helm/cavern/Chart.yaml
+++ b/deployment/helm/cavern/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.8
+version: 0.4.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deployment/helm/cavern/Chart.yaml
+++ b/deployment/helm/cavern/Chart.yaml
@@ -22,3 +22,8 @@ version: 0.3.8
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "0.7.7"
+
+dependencies:
+  - name: "utils"
+    version: "^0.1.0"
+    repository: "file://../utils"

--- a/deployment/helm/cavern/Chart.yaml
+++ b/deployment/helm/cavern/Chart.yaml
@@ -15,10 +15,10 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.3.4
+version: 0.3.8
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.7.6"
+appVersion: "0.7.7"

--- a/deployment/helm/cavern/config/cadc-log.properties
+++ b/deployment/helm/cavern/config/cadc-log.properties
@@ -1,0 +1,3 @@
+{{- range $val := .Values.deployment.cavern.loggingGroups }}
+group = {{ $val }}
+{{- end }}

--- a/deployment/helm/cavern/config/cadc-registry.properties
+++ b/deployment/helm/cavern/config/cadc-registry.properties
@@ -13,7 +13,7 @@ ivo://ivoa.net/sso#OAuth = {{ .Values.deployment.cavern.oidcURI }}
 ivo://ivoa.net/sso#OpenID = {{ .Values.deployment.cavern.oidcURI }}
 
 # Ignore this, it's only here to satisfy the availability check.
-# ivo://ivoa.net/std/CDP#proxy-1.0 = ivo://cadc.nrc.ca/cred
+ivo://ivoa.net/std/CDP#proxy-1.0 = ivo://cadc.nrc.ca/cred
 
 http://www.opencadc.org/std/posix#group-mapping-0.1 = {{ .Values.deployment.cavern.posixMapperResourceID }}
 http://www.opencadc.org/std/posix#user-mapping-0.1 = {{ .Values.deployment.cavern.posixMapperResourceID }}

--- a/deployment/helm/cavern/config/catalina.properties
+++ b/deployment/helm/cavern/config/catalina.properties
@@ -6,6 +6,8 @@ ca.nrc.cadc.util.Log4jInit.messageOnly=true
 # (default: ca.nrc.cadc.auth.NoOpIdentityManager)
 ca.nrc.cadc.auth.IdentityManager={{ .Values.deployment.cavern.identityManagerClass }}
 
+ca.nrc.cadc.ac.ACIdentityManager.requireCompletePosixPrincipal=true
+
 # database connection pools
 {{- with .Values.deployment.cavern.uws.db }}
 org.opencadc.cavern.uws.maxActive={{ .maxActive }}

--- a/deployment/helm/cavern/config/cavern.properties
+++ b/deployment/helm/cavern/config/cavern.properties
@@ -7,6 +7,8 @@ org.opencadc.cavern.filesystem.baseDir = {{ .Values.deployment.cavern.filesystem
 # This subpath needs to match the subpath in Skaha's deployment.  If that one is configurable, so must this one be!
 org.opencadc.cavern.filesystem.subPath = {{ .Values.deployment.cavern.filesystem.subPath }}
 
+org.opencadc.cavern.nodes.QuotaPlugin = {{ .Values.deployment.cavern.quotaPlugin }}
+
 {{- with .Values.deployment.cavern.filesystem.rootOwner }}
 # owner of root node has admin power
 org.opencadc.cavern.filesystem.rootOwner = {{ .adminUsername }}
@@ -31,10 +33,6 @@ org.opencadc.cavern.filesystem.rootOwner.gid = {{ .gid }}
 {{- end }}
 
 {{- end }}
-
-# (optional) keys to generate pre-auth URLs to cavern
-org.opencadc.cavern.privateKey = cavern-private.key
-org.opencadc.cavern.publicKey = cavern-public.key
 
 {{- with .Values.deployment.cavern.sshfs }}
 # (optional) base directory exposed for sshfs mounts

--- a/deployment/helm/cavern/templates/cavern-configmap.yaml
+++ b/deployment/helm/cavern/templates/cavern-configmap.yaml
@@ -5,3 +5,4 @@ metadata:
   namespace: {{ .Values.skaha.namespace }}
 data:
 {{ tpl (.Files.Glob "config/*").AsConfig . | indent 2 }}
+{{- include "utils.extraConfig" (dict "extraConfigData" .Values.deployment.cavern.extraConfigData) -}}

--- a/deployment/helm/cavern/templates/cavern-tomcat-deployment.yaml
+++ b/deployment/helm/cavern/templates/cavern-tomcat-deployment.yaml
@@ -59,6 +59,12 @@ spec:
         {{- with .Values.deployment.cavern.extraVolumeMounts }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+    {{- range $extraHost := .Values.deployment.extraHosts }}
+      hostAliases:
+        - ip: {{ $extraHost.ip }}
+          hostnames:
+            - {{ $extraHost.hostname }}
+    {{- end }}
       priorityClassName: uber-user-preempt-high
       serviceAccountName: skaha
       volumes:

--- a/deployment/helm/cavern/values.yaml
+++ b/deployment/helm/cavern/values.yaml
@@ -11,7 +11,7 @@ skaha:
 deployment:
   hostname: example.org
   cavern:
-    image: images.opencadc.org/platform/cavern:0.7.6
+    image: images.opencadc.org/platform/cavern:0.7.7
     imagePullPolicy: Always
 
     # How cavern identifies itself.
@@ -31,6 +31,12 @@ deployment:
 
     # Array of groups allowed to set the logging level.  If none set, then nobody can change the log level.
     # loggingGroups: []
+
+    # Simple Class name of the QuotaPlugin to use.
+    # - For CephFS deployments: CephFSQuotaPlugin
+    # - Default: NoQuotaPlugin
+    #
+    # quotaPlugin: {NoQuotaPlugin | CephFSQuotaPlug}
 
     # filesystem:
       # persistent data directory in container

--- a/deployment/helm/cavern/values.yaml
+++ b/deployment/helm/cavern/values.yaml
@@ -18,21 +18,23 @@ deployment:
     resourceID: "ivo://example.org/cavern"
 
     # Set the Registry URL pointing to the desired registry (https:// URL)
-    registryURL: https://spsrc27.iaa.csic.es/reg
+    # registryURL: https://example.org/reg
 
     # The Resource ID of the Service that contains the Posix Mapping information
-    posixMapperResourceID: "ivo://example.org/posix-mapper"
+    # posixMapperResourceID: "ivo://example.org/posix-mapper"
 
-    # URI or URL of the OIDC (IAM) server.  Used to validate incoming tokens.
-    oidcURI: https://ska-iam.stfc.ac.uk/
+    # URI or URL of the OIDC (IAM) server.  Used to validate incoming tokens.  Required.
+    # oidcURI: https://ska-iam.stfc.ac.uk/
 
-    # ID (URI) of the GMS Service.
-    gmsID: ivo://skao.int/gms
+    # ID (URI) of the GMS Service.  Required
+    # gmsID: ivo://skao.int/gms
 
     # Array of groups allowed to set the logging level.  If none set, then nobody can change the log level.
     # loggingGroups: []
 
-    # Simple Class name of the QuotaPlugin to use.
+    # Simple Class name of the QuotaPlugin to use.  This is used to request quota and folder size information
+    # from the underlying storage system.  Optional, defaults to NoQuotaPlugin.
+    #
     # - For CephFS deployments: CephFSQuotaPlugin
     # - Default: NoQuotaPlugin
     #
@@ -58,7 +60,7 @@ deployment:
       # sshfs:
       #   serverBase: {server}[:{port}]:{path}
 
-    # The IdentityManager class handling authentication.  This should generally be left alone
+    # The IdentityManager class handling authentication.  This should generally be left alone.
     identityManagerClass: org.opencadc.auth.StandardIdentityManager
 
     # For the UWS database.

--- a/deployment/helm/cavern/values.yaml
+++ b/deployment/helm/cavern/values.yaml
@@ -107,7 +107,14 @@ deployment:
         memory: "1Gi"
         cpu: "500m"
 
-# secrets:
+  # Specify extra hostnames that will be added to the Pod's /etc/hosts file.  Note that this is in the
+  # deployment object, not the skaha one.
+  # extraHosts:
+  #   - ip: 127.3.34.5
+  #     hostname: myhost.example.org
+  # extraHosts: []
+
+secrets:
   # Uncomment to enable local or self-signed CA certificates for your domain to be trusted.
   # cavern-cacert-secret:
   #   ca.crt: <base64 encoded CA crt>

--- a/deployment/helm/science-portal/Chart.yaml
+++ b/deployment/helm/science-portal/Chart.yaml
@@ -25,7 +25,7 @@ appVersion: "0.2.1"
 
 dependencies:
   - name: "redis"
-    version: "^18.4.0"
+    version: "^18.19.0"
     repository: "oci://registry-1.docker.io/bitnamicharts"
   - name: "utils"
     version: "^0.1.0"

--- a/deployment/helm/science-portal/config/cadc-log.properties
+++ b/deployment/helm/science-portal/config/cadc-log.properties
@@ -1,0 +1,3 @@
+{{- range $val := .Values.deployment.sciencePortal.loggingGroups }}
+group = {{ $val }}
+{{- end }}

--- a/deployment/helm/science-portal/templates/science-portal-config-configmap.yaml
+++ b/deployment/helm/science-portal/templates/science-portal-config-configmap.yaml
@@ -5,3 +5,4 @@ metadata:
   namespace: {{ .Values.skaha.namespace }}
 data:
 {{ tpl (.Files.Glob "config/*").AsConfig . | indent 2 }}
+{{- include "utils.extraConfig" (dict "extraConfigData" .Values.deployment.sciencePortal.extraConfigData) -}}

--- a/deployment/helm/science-portal/templates/science-portal-tomcat-deployment.yaml
+++ b/deployment/helm/science-portal/templates/science-portal-tomcat-deployment.yaml
@@ -46,6 +46,12 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- end }}
+    {{- range $extraHost := .Values.deployment.extraHosts }}
+      hostAliases:
+        - ip: {{ $extraHost.ip }}
+          hostnames:
+            - {{ $extraHost.hostname }}
+    {{- end }}
       volumes:
       - name: config-volume
         configMap:

--- a/deployment/helm/science-portal/values.yaml
+++ b/deployment/helm/science-portal/values.yaml
@@ -89,3 +89,6 @@ redis:
   architecture: 'standalone'
   auth:
     enabled: false
+  master:
+    persistence:
+      enabled: false

--- a/deployment/helm/skaha/Chart.yaml
+++ b/deployment/helm/skaha/Chart.yaml
@@ -22,3 +22,8 @@ version: 0.4.3
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
 appVersion: "0.16.1"
+
+dependencies:
+  - name: "utils"
+    version: "^0.1.0"
+    repository: "file://../utils"

--- a/deployment/helm/skaha/templates/skaha-config-configmap.yaml
+++ b/deployment/helm/skaha/templates/skaha-config-configmap.yaml
@@ -6,3 +6,4 @@ metadata:
 data:
 {{ tpl (.Files.Glob "config/*").AsConfig . | indent 2 }}
   {{- (.Files.Glob "skaha-config/*").AsConfig | nindent 2 }}
+{{- include "utils.extraConfig" (dict "extraConfigData" .Values.deployment.skaha.extraConfigData) -}}

--- a/deployment/helm/skaha/templates/skaha-tomcat-deployment.yaml
+++ b/deployment/helm/skaha/templates/skaha-tomcat-deployment.yaml
@@ -89,6 +89,12 @@ spec:
         {{- end }}
         securityContext:
           runAsUser: 0
+    {{- range $extraHost := .Values.deployment.extraHosts }}
+      hostAliases:
+        - ip: {{ $extraHost.ip }}
+          hostnames:
+            - {{ $extraHost.hostname }}
+    {{- end }}
       priorityClassName: {{ .Values.deployment.skaha.priorityClassName }}
       serviceAccountName: {{ .Values.deployment.skaha.serviceAccountName }}
       volumes:

--- a/deployment/helm/skaha/values.yaml
+++ b/deployment/helm/skaha/values.yaml
@@ -90,6 +90,13 @@ deployment:
     #     defaultMode: 420
     #     secretName: skaha-cacert-secret
 
+  # Specify extra hostnames that will be added to the Pod's /etc/hosts file.  Note that this is in the
+  # deployment object, not the skaha one.
+  # extraHosts:
+  #   - ip: 127.3.34.5
+  #     hostname: myhost.example.org
+  # extraHosts: []
+
 secrets:
   # Uncomment to enable local or self-signed CA certificates for your domain to be trusted.
   # skaha-cacert-secret:

--- a/deployment/helm/storage-ui/templates/storage-ui-config-configmap.yaml
+++ b/deployment/helm/storage-ui/templates/storage-ui-config-configmap.yaml
@@ -5,3 +5,4 @@ metadata:
   namespace: {{ .Values.skaha.namespace }}
 data:
 {{ tpl (.Files.Glob "config/*").AsConfig . | indent 2 }}
+{{- include "utils.extraConfig" (dict "extraConfigData" .Values.deployment.storageUI.extraConfigData) -}}

--- a/deployment/helm/storage-ui/templates/storage-ui-tomcat-deployment.yaml
+++ b/deployment/helm/storage-ui/templates/storage-ui-tomcat-deployment.yaml
@@ -46,6 +46,12 @@ spec:
         {{- toYaml . | nindent 8 }}
         {{- end }}
         {{- end }}
+    {{- range $extraHost := .Values.deployment.extraHosts }}
+      hostAliases:
+        - ip: {{ $extraHost.ip }}
+          hostnames:
+            - {{ $extraHost.hostname }}
+    {{- end }}
       volumes:
       - name: config-volume
         configMap:

--- a/deployment/helm/storage-ui/values.yaml
+++ b/deployment/helm/storage-ui/values.yaml
@@ -104,3 +104,6 @@ redis:
   architecture: 'standalone'
   auth:
     enabled: false
+  master:
+    persistence:
+      enabled: false

--- a/deployment/helm/utils/templates/_common.yaml
+++ b/deployment/helm/utils/templates/_common.yaml
@@ -11,3 +11,34 @@ This takes an array of three values:
 {{- $tpl := fromYaml (include (index . 2) $top) | default (dict ) -}}
 {{- toYaml (merge $overrides $tpl) -}}
 {{- end -}}
+
+{{- /*
+utils.extraConfig will pull any extra config data from the
+.extraConfigData input YAML object.
+
+The .extraConfigData is expected to contain a valid dict with
+key: data-value pairings.
+
+Any keys that end in ".key" are treated as base64 encoded data
+and decoded.
+
+Example:
+values.yaml:
+...
+system:
+  extraConfigData:
+    myfile.txt: somedata
+    mysecret.key: L03DJSLKJLKSFD=
+...
+
+{{- include "utils.extraConfig" (dict "extraConfigData" .Values.system.extraConfigData) -}}
+*/}}
+{{- define "utils.extraConfig" -}}
+{{- range $configFileName, $configFileValue := .extraConfigData }}
+{{- if $configFileName | hasSuffix ".key" }}
+  {{ $configFileName }}: {{ $configFileValue | b64dec | quote }}
+{{- else }}
+  {{ $configFileName }}: {{ $configFileValue }}
+{{- end }}
+{{- end }}
+{{- end -}}

--- a/skaha/VERSION
+++ b/skaha/VERSION
@@ -1,6 +1,6 @@
 ## deployable containers have a semantic and build tag
 # version tag: major.minor.patch
 # build version tag: timestamp
-VER=0.16.1
+VER=0.17.0
 TAGS="${VER} ${VER}-$(date -u +"%Y%m%dT%H%M%S")"
 unset VER

--- a/skaha/src/scripts/add-user
+++ b/skaha/src/scripts/add-user
@@ -75,18 +75,14 @@ rm casa-config.tar
 chown -R $USERID:$USERID $HOMEDIR/.casa
 echo " Adding CASA configuration: OK"
 
-echo -n "  Setting user quota to ${QUOTA}G..."
-
-# Ignore the errors from the CephFS xattr in case they're not supported.
-setfattr -n ceph.quota.max_bytes -v ${QUOTA}000000000 $HOMEDIR 2> /dev/null
-STAT=${?}
-
-if [[ ! "X${STAT}" == "X0" ]]; then
-  echo "No CephFS extended attribute plugin found.  Skipping..."
-fi
-
+echo "  Setting user quota to ${QUOTA}G..."
 setfattr -n user.ivo://ivoa.net/vospace/core#quota -v ${QUOTA}000000000 $HOMEDIR
-echo " Setting user quota to ${QUOTA}G: OK"
+echo "  Setting user quota to ${QUOTA}G: Done"
+
+echo "  Setting CephFS quota to ${QUOTA}G..."
+# Ignore the errors from the CephFS xattr in case they're not supported.
+eval $(setfattr -n ceph.quota.max_bytes -v ${QUOTA}000000000 $HOMEDIR)
+echo "  Setting CephFS quota to ${QUOTA}G: Done"
 
 TS=$(date)
 echo "$TS $SELF DONE"


### PR DESCRIPTION
Proper fix for the `add-user` script in Skaha
Update Cavern Chart to use latest Cavern image
Added `extraConfigData` to support adding `RsaSignaturePub.key` for CANFAR deployment
Added `extraHosts` to support non-public DNS registry, such as local `cadc.dao.nrc.ca` domains.