### PR TITLE
Registry documentation fixes

### DIFF
--- a/deployment/helm/README.md
+++ b/deployment/helm/README.md
@@ -17,7 +17,7 @@
 ## Dependencies
 
 - An existing Kubernetes cluster.
-- An IVOA Registry (See the [Current SKAO Registry](https://spsrc27.iaa.csic.es/reg))
+- An [Service Registry deployment](https://github.com/opencadc/reg/tree/master/reg)
 
 ## Quick Start
 


### PR DESCRIPTION
- Remove reference to SKA registry
- Rename 'IVOA registry' to 'Service registry'