### PR TITLE
Add extraHosts support to posix mapper, following local convention

### DIFF
--- a/deployment/helm/README.md
+++ b/deployment/helm/README.md
@@ -149,6 +149,18 @@ deployment:
     #     defaultMode: 420
     #     secretName: posix-manager-cacert-secret
 
+  # Specify extra hostnames that will be added to the Pod's /etc/hosts file.  Note that this is in the
+  # deployment object, not the posixMapper one.
+  #
+  # These entries get added as hostAliases entries to the Deployment.
+  #
+  # Example:
+  # extraHosts:
+  #   - ip: 127.3.34.5
+  #     hostname: myhost.example.org
+  #
+  # extraHosts: []
+
 # Declare the storage for the skaha service to use.
 storage:
   service:

--- a/deployment/helm/posix-mapper/templates/posix-mapper-tomcat-deployment.yaml
+++ b/deployment/helm/posix-mapper/templates/posix-mapper-tomcat-deployment.yaml
@@ -45,6 +45,12 @@ spec:
         {{- with .Values.deployment.posixMapper.extraVolumeMounts }}
         {{- toYaml . | nindent 8 }}
         {{- end }}
+    {{- range $extraHost := .Values.deployment.extraHosts }}
+      hostAliases:
+        - ip: {{ $extraHost.ip }}
+          hostnames:
+            - {{ $extraHost.hostname }}
+    {{- end }}
       volumes:
       - name: config-volume
         configMap:

--- a/deployment/helm/posix-mapper/values.yaml
+++ b/deployment/helm/posix-mapper/values.yaml
@@ -58,6 +58,17 @@ deployment:
     #     defaultMode: 420
     #     secretName: posix-manager-cacert-secret
 
+  # Specify extra hostnames that will be added to the Pod's /etc/hosts file.  Note that this is in the
+  # deployment object, not the posixMapper one.
+  #
+  # These entries get added as hostAliases entries to the Deployment.
+  #
+  # Example:
+  # extraHosts:
+  #   - ip: 127.3.34.5
+  #     hostname: myhost.example.org
+  #
+  # extraHosts: []
 secrets:
   # Uncomment to enable local or self-signed CA certificates for your domain to be trusted.
   # posix-manager-cacert-secret:


### PR DESCRIPTION
When attempting to setup the POSIX mapper I was having errors reaching my local registry and discovered that that was due to the hostname I was using resolving to the local loopback address and thus wasn't functioning from within a pod.

Most of the other charts had support for adding host aliases, so I've added the same for the posix mapper helm chart following the conventions from the other charts in the repo.