### PR TITLE
add 'runAsNonRoot: true' to skaha-workload pods (CADC-13548)

### DIFF
--- a/deployment/helm/skaha/Chart.yaml
+++ b/deployment/helm/skaha/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.15
+version: 0.4.16
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deployment/helm/skaha/skaha-config/launch-carta.yaml
+++ b/deployment/helm/skaha/skaha-config/launch-carta.yaml
@@ -31,6 +31,7 @@ spec:
         runAsGroup: ${skaha.posixid}
         fsGroup: ${skaha.posixid}
         supplementalGroups: [${skaha.supgroups}]
+        runAsNonRoot: true
       priorityClassName: uber-user-preempt-medium
       hostname: "${software.hostname}"
       initContainers:
@@ -68,6 +69,7 @@ spec:
         securityContext:
           runAsUser: ${skaha.posixid}
           runAsGroup: ${skaha.posixid}
+          runAsNonRoot: true
       containers:
       - name: "${skaha.jobname}"
         env:
@@ -87,6 +89,7 @@ spec:
           runAsUser: ${skaha.posixid}
           runAsGroup: ${skaha.posixid}
           allowPrivilegeEscalation: false
+          runAsNonRoot: true
         image: ${software.imageid}
         command: ["/bin/sh", "-c"]
         args:

--- a/deployment/helm/skaha/skaha-config/launch-contributed.yaml
+++ b/deployment/helm/skaha/skaha-config/launch-contributed.yaml
@@ -31,6 +31,7 @@ spec:
         runAsGroup: ${skaha.posixid}
         fsGroup: ${skaha.posixid}
         supplementalGroups: [${skaha.supgroups}]
+        runAsNonRoot: true
       priorityClassName: uber-user-preempt-medium
       hostname: "${software.hostname}"
       initContainers:
@@ -45,6 +46,7 @@ spec:
         securityContext:
           runAsUser: ${skaha.posixid}
           runAsGroup: ${skaha.posixid}
+          runAsNonRoot: true
       - name: init-users-groups
         image: images.opencadc.org/library/cadc-tomcat:1
         command: ["/init-users-groups/init-users-groups-from-service.sh"]
@@ -68,6 +70,7 @@ spec:
         securityContext:
           runAsUser: ${skaha.posixid}
           runAsGroup: ${skaha.posixid}
+          runAsNonRoot: true
       containers:
       - name: "${skaha.jobname}"
         env:
@@ -122,6 +125,7 @@ spec:
           runAsUser: ${skaha.posixid}
           runAsGroup: ${skaha.posixid}
           allowPrivilegeEscalation: false
+          runAsNonRoot: true
       volumes:
       - name: cavern-volume
         persistentVolumeClaim:

--- a/deployment/helm/skaha/skaha-config/launch-desktop-app.yaml
+++ b/deployment/helm/skaha/skaha-config/launch-desktop-app.yaml
@@ -31,6 +31,7 @@ spec:
         runAsGroup: ${skaha.posixid}
         fsGroup: ${skaha.posixid}
         supplementalGroups: [${skaha.supgroups}]
+        runAsNonRoot: true
       priorityClassName: uber-user-preempt-medium
       hostname: "${software.hostname}"
       initContainers:
@@ -45,6 +46,7 @@ spec:
         securityContext:
           runAsUser: ${skaha.posixid}
           runAsGroup: ${skaha.posixid}
+          runAsNonRoot: true
       - name: init-users-groups
         image: images.opencadc.org/library/cadc-tomcat:1
         command: ["/init-users-groups/init-users-groups-from-service.sh"]
@@ -68,6 +70,7 @@ spec:
         securityContext:
           runAsUser: ${skaha.posixid}
           runAsGroup: ${skaha.posixid}
+          runAsNonRoot: true
       containers:
       - name: "${software.containername}"
         command: ["/skaha-system/start-desktop-software.sh"]
@@ -93,6 +96,7 @@ spec:
           runAsUser: ${skaha.posixid}
           runAsGroup: ${skaha.posixid}
           allowPrivilegeEscalation: false
+          runAsNonRoot: true
         image: "${software.imageid}"
         workingDir: "${SKAHA_TLD}/home/${skaha.userid}"
         imagePullPolicy: Always

--- a/deployment/helm/skaha/skaha-config/launch-desktop.yaml
+++ b/deployment/helm/skaha/skaha-config/launch-desktop.yaml
@@ -31,6 +31,7 @@ spec:
         runAsGroup: ${skaha.posixid}
         fsGroup: ${skaha.posixid}
         supplementalGroups: [${skaha.supgroups}]
+        runAsNonRoot: true
       priorityClassName: uber-user-preempt-medium
       hostname: "${software.hostname}"
       initContainers:
@@ -45,6 +46,7 @@ spec:
         securityContext:
           runAsUser: ${skaha.posixid}
           runAsGroup: ${skaha.posixid}
+          runAsNonRoot: true
       - name: init-users-groups
         image: images.opencadc.org/library/cadc-tomcat:1
         command: ["/init-users-groups/init-users-groups-from-service.sh"]
@@ -68,6 +70,7 @@ spec:
         securityContext:
           runAsUser: ${skaha.posixid}
           runAsGroup: ${skaha.posixid}
+          runAsNonRoot: true
       containers:
       - name: "${skaha.jobname}"
         command: ["/skaha-system/start-desktop.sh"]
@@ -92,6 +95,7 @@ spec:
           runAsUser: ${skaha.posixid}
           runAsGroup: ${skaha.posixid}
           allowPrivilegeEscalation: false
+          runAsNonRoot: true
         image: ${software.imageid}
         imagePullPolicy: Always
         resources:

--- a/deployment/helm/skaha/skaha-config/launch-headless.yaml
+++ b/deployment/helm/skaha/skaha-config/launch-headless.yaml
@@ -40,6 +40,7 @@ spec:
         securityContext:
           runAsUser: ${skaha.posixid}
           runAsGroup: ${skaha.posixid}
+          runAsNonRoot: true
       - name: init-users-groups
         image: images.opencadc.org/library/cadc-tomcat:1
         command: ["/init-users-groups/init-users-groups-from-service.sh"]
@@ -63,11 +64,13 @@ spec:
         securityContext:
           runAsUser: ${skaha.posixid}
           runAsGroup: ${skaha.posixid}
+          runAsNonRoot: true
       securityContext:
         runAsUser: ${skaha.posixid}
         runAsGroup: ${skaha.posixid}
         fsGroup: ${skaha.posixid}
         supplementalGroups: [${skaha.supgroups}]
+        runAsNonRoot: true
       ${headless.priority}
       containers:
       - name: "${skaha.jobname}"
@@ -89,6 +92,7 @@ spec:
           runAsUser: ${skaha.posixid}
           runAsGroup: ${skaha.posixid}
           allowPrivilegeEscalation: false
+          runAsNonRoot: true
         workingDir: "${SKAHA_TLD}/home/${skaha.userid}"
         imagePullPolicy: Always
         resources:

--- a/deployment/helm/skaha/skaha-config/launch-notebook.yaml
+++ b/deployment/helm/skaha/skaha-config/launch-notebook.yaml
@@ -31,6 +31,7 @@ spec:
         runAsGroup: ${skaha.posixid}
         fsGroup: ${skaha.posixid}
         supplementalGroups: [${skaha.supgroups}]
+        runAsNonRoot: true
       priorityClassName: uber-user-preempt-medium
       hostname: "${software.hostname}"
       initContainers:
@@ -45,6 +46,7 @@ spec:
         securityContext:
           runAsUser: ${skaha.posixid}
           runAsGroup: ${skaha.posixid}
+          runAsNonRoot: true
       - name: init-users-groups
         image: images.opencadc.org/library/cadc-tomcat:1
         command: ["/init-users-groups/init-users-groups-from-service.sh"]
@@ -68,6 +70,7 @@ spec:
         securityContext:
           runAsUser: ${skaha.posixid}
           runAsGroup: ${skaha.posixid}
+          runAsNonRoot: true
       containers:
       - name: "${skaha.jobname}"
         env:
@@ -147,6 +150,7 @@ spec:
           runAsUser: ${skaha.posixid}
           runAsGroup: ${skaha.posixid}
           allowPrivilegeEscalation: false
+          runAsNonRoot: true
       volumes:
       - name: start-jupyterlab
         configMap:


### PR DESCRIPTION
To allow RCS testing of Kyverno enforcement.