### PR TITLE
Explicit/refactored security contexts for containers

### DIFF
--- a/deployment/helm/skaha/Chart.yaml
+++ b/deployment/helm/skaha/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.16
+version: 0.4.17
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deployment/helm/skaha/skaha-config/launch-carta.yaml
+++ b/deployment/helm/skaha/skaha-config/launch-carta.yaml
@@ -44,8 +44,11 @@ spec:
         - mountPath: "/etc-group"
           name: etc-group
         securityContext:
-          runAsUser: ${skaha.posixid}
-          runAsGroup: ${skaha.posixid}
+          privileged: false
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
       - name: init-users-groups
         image: images.opencadc.org/library/cadc-tomcat:1
         command: ["/init-users-groups/init-users-groups-from-service.sh"]
@@ -67,9 +70,11 @@ spec:
         - name: REGISTRY_URL
           value: ${REGISTRY_URL}
         securityContext:
-          runAsUser: ${skaha.posixid}
-          runAsGroup: ${skaha.posixid}
-          runAsNonRoot: true
+          privileged: false
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
       containers:
       - name: "${skaha.jobname}"
         env:
@@ -86,10 +91,11 @@ spec:
         - name: OMP_NUM_THREADS
           value: "${software.requests.cores}"
         securityContext:
-          runAsUser: ${skaha.posixid}
-          runAsGroup: ${skaha.posixid}
+          privileged: false
           allowPrivilegeEscalation: false
-          runAsNonRoot: true
+          capabilities:
+            drop:
+              - ALL
         image: ${software.imageid}
         command: ["/bin/sh", "-c"]
         args:

--- a/deployment/helm/skaha/skaha-config/launch-contributed.yaml
+++ b/deployment/helm/skaha/skaha-config/launch-contributed.yaml
@@ -44,9 +44,11 @@ spec:
         - mountPath: "/etc-group"
           name: etc-group
         securityContext:
-          runAsUser: ${skaha.posixid}
-          runAsGroup: ${skaha.posixid}
-          runAsNonRoot: true
+          privileged: false
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
       - name: init-users-groups
         image: images.opencadc.org/library/cadc-tomcat:1
         command: ["/init-users-groups/init-users-groups-from-service.sh"]
@@ -68,9 +70,11 @@ spec:
         - name: REGISTRY_URL
           value: ${REGISTRY_URL}
         securityContext:
-          runAsUser: ${skaha.posixid}
-          runAsGroup: ${skaha.posixid}
-          runAsNonRoot: true
+          privileged: false
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
       containers:
       - name: "${skaha.jobname}"
         env:
@@ -122,10 +126,11 @@ spec:
           name: scratch-dir
           subPath: "${skaha.sessionid}"
         securityContext:
-          runAsUser: ${skaha.posixid}
-          runAsGroup: ${skaha.posixid}
+          privileged: false
           allowPrivilegeEscalation: false
-          runAsNonRoot: true
+          capabilities:
+            drop:
+              - ALL
       volumes:
       - name: cavern-volume
         persistentVolumeClaim:

--- a/deployment/helm/skaha/skaha-config/launch-desktop-app.yaml
+++ b/deployment/helm/skaha/skaha-config/launch-desktop-app.yaml
@@ -44,9 +44,11 @@ spec:
         - mountPath: "/etc-group"
           name: etc-group
         securityContext:
-          runAsUser: ${skaha.posixid}
-          runAsGroup: ${skaha.posixid}
-          runAsNonRoot: true
+          privileged: false
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
       - name: init-users-groups
         image: images.opencadc.org/library/cadc-tomcat:1
         command: ["/init-users-groups/init-users-groups-from-service.sh"]
@@ -68,9 +70,11 @@ spec:
         - name: REGISTRY_URL
           value: ${REGISTRY_URL}
         securityContext:
-          runAsUser: ${skaha.posixid}
-          runAsGroup: ${skaha.posixid}
-          runAsNonRoot: true
+          privileged: false
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
       containers:
       - name: "${software.containername}"
         command: ["/skaha-system/start-desktop-software.sh"]
@@ -93,10 +97,11 @@ spec:
         - name: OMP_NUM_THREADS
           value: "${software.requests.cores}"
         securityContext:
-          runAsUser: ${skaha.posixid}
-          runAsGroup: ${skaha.posixid}
+          privileged: false
           allowPrivilegeEscalation: false
-          runAsNonRoot: true
+          capabilities:
+            drop:
+              - ALL
         image: "${software.imageid}"
         workingDir: "${SKAHA_TLD}/home/${skaha.userid}"
         imagePullPolicy: Always

--- a/deployment/helm/skaha/skaha-config/launch-desktop.yaml
+++ b/deployment/helm/skaha/skaha-config/launch-desktop.yaml
@@ -44,9 +44,11 @@ spec:
         - mountPath: "/etc-group"
           name: etc-group
         securityContext:
-          runAsUser: ${skaha.posixid}
-          runAsGroup: ${skaha.posixid}
-          runAsNonRoot: true
+          privileged: false
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
       - name: init-users-groups
         image: images.opencadc.org/library/cadc-tomcat:1
         command: ["/init-users-groups/init-users-groups-from-service.sh"]
@@ -68,9 +70,11 @@ spec:
         - name: REGISTRY_URL
           value: ${REGISTRY_URL}
         securityContext:
-          runAsUser: ${skaha.posixid}
-          runAsGroup: ${skaha.posixid}
-          runAsNonRoot: true
+          privileged: false
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
       containers:
       - name: "${skaha.jobname}"
         command: ["/skaha-system/start-desktop.sh"]
@@ -92,10 +96,11 @@ spec:
         - name: SKAHA_API_VERSION
           value: "v0"  
         securityContext:
-          runAsUser: ${skaha.posixid}
-          runAsGroup: ${skaha.posixid}
+          privileged: false
           allowPrivilegeEscalation: false
-          runAsNonRoot: true
+          capabilities:
+            drop:
+              - ALL
         image: ${software.imageid}
         imagePullPolicy: Always
         resources:

--- a/deployment/helm/skaha/skaha-config/launch-headless.yaml
+++ b/deployment/helm/skaha/skaha-config/launch-headless.yaml
@@ -38,9 +38,11 @@ spec:
         - mountPath: "/etc-group"
           name: etc-group
         securityContext:
-          runAsUser: ${skaha.posixid}
-          runAsGroup: ${skaha.posixid}
-          runAsNonRoot: true
+          privileged: false
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
       - name: init-users-groups
         image: images.opencadc.org/library/cadc-tomcat:1
         command: ["/init-users-groups/init-users-groups-from-service.sh"]
@@ -62,9 +64,11 @@ spec:
         - name: REGISTRY_URL
           value: ${REGISTRY_URL}
         securityContext:
-          runAsUser: ${skaha.posixid}
-          runAsGroup: ${skaha.posixid}
-          runAsNonRoot: true
+          privileged: false
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
       securityContext:
         runAsUser: ${skaha.posixid}
         runAsGroup: ${skaha.posixid}
@@ -89,10 +93,11 @@ spec:
         - name: OMP_NUM_THREADS
           value: "${software.requests.cores}"
         securityContext:
-          runAsUser: ${skaha.posixid}
-          runAsGroup: ${skaha.posixid}
+          privileged: false
           allowPrivilegeEscalation: false
-          runAsNonRoot: true
+          capabilities:
+            drop:
+              - ALL
         workingDir: "${SKAHA_TLD}/home/${skaha.userid}"
         imagePullPolicy: Always
         resources:

--- a/deployment/helm/skaha/skaha-config/launch-notebook.yaml
+++ b/deployment/helm/skaha/skaha-config/launch-notebook.yaml
@@ -44,9 +44,11 @@ spec:
         - mountPath: "/etc-group"
           name: etc-group
         securityContext:
-          runAsUser: ${skaha.posixid}
-          runAsGroup: ${skaha.posixid}
-          runAsNonRoot: true
+          privileged: false
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
       - name: init-users-groups
         image: images.opencadc.org/library/cadc-tomcat:1
         command: ["/init-users-groups/init-users-groups-from-service.sh"]
@@ -68,9 +70,11 @@ spec:
         - name: REGISTRY_URL
           value: ${REGISTRY_URL}
         securityContext:
-          runAsUser: ${skaha.posixid}
-          runAsGroup: ${skaha.posixid}
-          runAsNonRoot: true
+          privileged: false
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+              - ALL
       containers:
       - name: "${skaha.jobname}"
         env:
@@ -147,10 +151,11 @@ spec:
           name: scratch-dir
           subPath: "${skaha.sessionid}"
         securityContext:
-          runAsUser: ${skaha.posixid}
-          runAsGroup: ${skaha.posixid}
+          privileged: false
           allowPrivilegeEscalation: false
-          runAsNonRoot: true
+          capabilities:
+            drop:
+              - ALL
       volumes:
       - name: start-jupyterlab
         configMap:


### PR DESCRIPTION
```
kubectl explain pod.spec.securityContext
kubectl explain pod.spec.containers.securityContext
```
Things that can only be in pod securityContext:
	fsGroup, fsGroupChangePolicy
	supplementalGroups
	sysctls
Things that can only be in container securityContext:
	allowPrivilegeEscalation
	capabilities			
	privileged			
	procMount
	readOnlyRootFilesystem
Everything else can be in either, but pod-level properties apply to all containers by default unless overridden by the container securityContext.

From what I saw every pod spec of every job already had
```
      securityContext:
        runAsUser: ${skaha.posixid}
        runAsGroup: ${skaha.posixid}
        fsGroup: ${skaha.posixid}
        supplementalGroups: [${skaha.supgroups}]
        runAsNonRoot: true
```
so none of those need to be set again in containers, while OTOH other container-level security controls need to be applied.

This MR:
- removes redundant settings in the container sec Con that were applied already in the pod sec Con
- applies additional explicit security settings in container sec Cons that can only be applied there

Overall this should make the different securityContexts more explicit and consistent and make Skaha more secure and portable.