### PR TITLE
update cavern securityContexts

### DIFF
--- a/deployment/helm/cavern/Chart.yaml
+++ b/deployment/helm/cavern/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.2
+version: 0.4.3
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deployment/helm/cavern/templates/cavern-tomcat-deployment.yaml
+++ b/deployment/helm/cavern/templates/cavern-tomcat-deployment.yaml
@@ -21,6 +21,8 @@ spec:
       securityContext:
         fsGroup: {{ .rootOwner.gid }}
         runAsUser: 0
+        seccompProfile:
+          type: RuntimeDefault
       initContainers:
       - name: init-{{ $.Release.Name }}-fs
         image: busybox
@@ -29,6 +31,8 @@ spec:
         volumeMounts:
         - mountPath: "{{ .dataDir }}"
           name: cavern-volume
+        securityContext:
+          allowPrivilegeEscalation: false
 {{- end }}
       containers:
       - image: {{ .Values.deployment.cavern.image }}
@@ -41,6 +45,8 @@ spec:
           limits:
             memory: {{ .Values.deployment.cavern.resources.limits.memory }}
             cpu: {{ .Values.deployment.cavern.resources.limits.cpu }}
+        securityContext:
+          allowPrivilegeEscalation: false
         {{- with .Values.deployment.cavern.extraEnv }}
         env:
         {{- toYaml . | nindent 8 }}


### PR DESCRIPTION
This is required for the science platform to run on the upgraded Keel cluster, where PodSecurityPolicy is being deprecated and Kyverno is being used instead to enforce security policies.

On keel I confirm the science platform has always had `allowPrivilegeEscalation: false`   and RuntimeDefault  seccomp profile, but it was applied in a hidden way by PSP, which is no longer possible. Now it must be set explicitly instead.

See https://github.com/opencadc/science-platform/pull/664  for related background info.

Please test and deploy on keel-dev ASAP.