### PR TITLE
update skaha securityContexts

### DIFF
--- a/deployment/helm/skaha/Chart.yaml
+++ b/deployment/helm/skaha/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.17
+version: 0.4.18
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/deployment/helm/skaha/templates/skaha-tomcat-deployment.yaml
+++ b/deployment/helm/skaha/templates/skaha-tomcat-deployment.yaml
@@ -18,6 +18,9 @@ spec:
     spec:
       imagePullSecrets:
         - name: regcred
+      securityContext:
+        seccompProfile:
+          type: RuntimeDefault
       initContainers:
       - name: init-skaha-service
         image: busybox
@@ -30,6 +33,8 @@ spec:
         env:
         - name: SKAHA_TLD
           value: "{{ .Values.deployment.skaha.skahaTld }}"
+        securityContext:
+          allowPrivilegeEscalation: false
       containers:
       - env: 
         - name: skaha.hostname
@@ -89,6 +94,7 @@ spec:
         {{- end }}
         securityContext:
           runAsUser: 0
+          allowPrivilegeEscalation: false
 {{- with .Values.deployment.extraHosts }}
       hostAliases:
 {{- range $extraHost := . }}


### PR DESCRIPTION
This is required for the science platform to run on the upgraded Keel cluster, where PodSecurityPolicy is deprecated and Kyverno is used instead to enforce security policies.

On keel I confirm the science platform has always had `allowPrivilegeEscalation: false` and RuntimeDefault  seccomp profile, but it was applied in a hidden way by PSP, which is no longer possible. Now it must be set explicitly instead.

See https://github.com/opencadc/science-platform/pull/664  for related background info.

Please update and test on keel-dev ASAP.