### PR TITLE
update sshd securityContexts

### DIFF
--- a/deployment/k8s-config/kustomize/base/sshd/arc-sshd-deployment.yaml
+++ b/deployment/k8s-config/kustomize/base/sshd/arc-sshd-deployment.yaml
@@ -33,6 +33,8 @@ spec:
           limits:
             memory: "8Gi"
             cpu: "4"
+        securityContext:
+          allowPrivilegeEscalation: false
         ports:
         - containerPort: 64022
           protocol: TCP
@@ -66,6 +68,8 @@ spec:
           subPath: ssh_host_rsa_key
       securityContext:
         runAsUser: 0
+        seccompProfile:
+          type: RuntimeDefault
       priorityClassName: uber-user-preempt-high
       serviceAccountName: skaha
       volumes:


### PR DESCRIPTION
This is required for the science platform to run on the upgraded Keel cluster, where PodSecurityPolicy is being deprecated and Kyverno is being used instead to enforce security policies.

On keel I confirm the science platform has always had `allowPrivilegeEscalation: false` and RuntimeDefault  seccomp profile, but it was applied in a hidden way by PSP, which is no longer possible. Now it must be set explicitly instead.

See https://github.com/opencadc/science-platform/pull/664  for related background info.

Please update and test on keel-dev ASAP.