### PR TITLE
Api token fix

### DIFF
--- a/deployment/helm/skaha/CHANGELOG.md
+++ b/deployment/helm/skaha/CHANGELOG.md
@@ -1,4 +1,7 @@
-# CHANGELOG for Skaha User Session API (Chart 0.4.3)
+# CHANGELOG for Skaha User Session API (Chart 0.4.23)
+
+## 2024.09.04
+- Fix for Desktop Applications not starting due to API token being overwritten
 
 ## 2024.05.06
 - Small change to deploy on CADC infrastructure with CephFS quotas

--- a/deployment/helm/skaha/Chart.yaml
+++ b/deployment/helm/skaha/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.4.22
+version: 0.4.23
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.19.0"
+appVersion: "0.19.1"
 
 dependencies:
   - name: "utils"

--- a/deployment/helm/skaha/desktop-template/start-software-sh.template
+++ b/deployment/helm/skaha/desktop-template/start-software-sh.template
@@ -1,7 +1,9 @@
 #!/bin/bash
 HOST=(HOST)
-TOKEN_FILE="${HOME}/.token/.skaha"
-TOKEN=$(cat ${TOKEN_FILE})
+
+# Callback token
+TOKEN="${DESKTOP_SESSION_APP_TOKEN}"
+
 handle_error() {
     echo "$1"
     echo "Please enter Ctl+C when you are ready to exit the xterm."
@@ -11,10 +13,10 @@ handle_error() {
 }
 
 get_resource_options() {
-    if [ -e "${TOKEN_FILE}" ]; then
-      resources=`curl -s -L -k --header "x-auth-token-skaha: ${TOKEN}" https://(HOST)/skaha/(SKAHA_API_VERSION)/context`
-    else
+    if [ -z "${TOKEN}" ]; then
       handle_error "[skaha] No credentials to call back to Skaha with."
+    else
+      resources=`curl -s -L -k --header "x-auth-token-skaha: ${TOKEN}" https://(HOST)/skaha/(SKAHA_API_VERSION)/context`
     fi   
      core_default=`echo $resources | jq .defaultCores`
      core_options=`echo $resources | jq .availableCores[] | tr '\n' ' '`
@@ -84,10 +86,10 @@ prompt_user() {
         if [[ -z "${yn}" || ${yn} == "n" || ${yn} == "N" ]]; then
             echo "Launching (NAME)..."
 
-            if [ -e "${TOKEN_FILE}" ]; then
-              app_id=`curl -s -L -k --header "x-auth-token-skaha: ${TOKEN}" -d "image=(IMAGE_ID)" --data-urlencode "param=(NAME)" https://(HOST)/skaha/(SKAHA_API_VERSION)/session/${VNC_PW}/app`
-            else
+            if [ -z "${TOKEN}" ]; then
               handle_error "[skaha] No credentials to call back to Skaha with."
+            else
+              app_id=`curl -s -L -k --header "x-auth-token-skaha: ${TOKEN}" -d "image=(IMAGE_ID)" --data-urlencode "param=(NAME)" https://(HOST)/skaha/(SKAHA_API_VERSION)/session/${VNC_PW}/app`
             fi 
             break
         elif [[ ${yn} == "y" || ${yn} == "Y" ]]; then
@@ -96,10 +98,10 @@ prompt_user() {
             get_ram || handle_error "Error obtaining the amount of ram to allocate."
             echo "Launching (NAME)..."
 
-            if [ -e "${TOKEN_FILE}" ]; then
-              app_id=`curl -s -L -k --header "x-auth-token-skaha: ${TOKEN}" -d "cores=${cores}" -d "ram=$ram" -d "image=(IMAGE_ID)" --data-urlencode "param=(NAME)" https://(HOST)/skaha/(SKAHA_API_VERSION)/session/${VNC_PW}/app`
+            if [ -z "${TOKEN}" ]; then
+              handle_error "[skaha] No credentials to call back to Skaha with."              
             else
-              handle_error "[skaha] No credentials to call back to Skaha with."
+              app_id=`curl -s -L -k --header "x-auth-token-skaha: ${TOKEN}" -d "cores=${cores}" -d "ram=$ram" -d "image=(IMAGE_ID)" --data-urlencode "param=(NAME)" https://(HOST)/skaha/(SKAHA_API_VERSION)/session/${VNC_PW}/app`
             fi   
             break
         else 
@@ -118,10 +120,10 @@ get_status() {
     status=""
     local n=0
     sleep 1
-    if [ -e "${TOKEN_FILE}" ]; then
-        curl_out=`curl -s -L -k --header "x-auth-token-skaha: ${TOKEN}" https://(HOST)/skaha/(SKAHA_API_VERSION)/session/${VNC_PW}/app/$1`
-    else
+    if [ -z "${TOKEN}" ]; then
         handle_error "[skaha] No credentials to call back to Skaha with."
+    else
+        curl_out=`curl -s -L -k --header "x-auth-token-skaha: ${TOKEN}" https://(HOST)/skaha/(SKAHA_API_VERSION)/session/${VNC_PW}/app/$1`
     fi
 
     while [[ ${curl_out} != *"status"* ]]; do
@@ -132,12 +134,8 @@ get_status() {
         fi
         sleep 1
 
-        if [ -e "${HOME}/.token/.skaha" ]; then
-          curl_out=`curl -s -L -k --header "x-auth-token-skaha: ${TOKEN}" https://(HOST)/skaha/(SKAHA_API_VERSION)/session/${VNC_PW}/app/$1`
-        else
-          handle_error "[skaha] No credentials to call back to Skaha with."
-        fi   
-             
+        # No need to check for the Token again as it passed above.
+        curl_out=`curl -s -L -k --header "x-auth-token-skaha: ${TOKEN}" https://(HOST)/skaha/(SKAHA_API_VERSION)/session/${VNC_PW}/app/$1`             
     done
 }
 

--- a/deployment/helm/skaha/init-users-groups-config/init-users-groups-from-service.sh
+++ b/deployment/helm/skaha/init-users-groups-config/init-users-groups-from-service.sh
@@ -51,7 +51,7 @@ if [[ "${POSIX_MAPPER_URI}" == http* ]] ; then
     TRIMMED_POSIX_MAPPER_URL=`echo "${POSIX_MAPPER_URI}" | tr -s \/ | sed 's/\(.*\)\/$/\1/'`
     POSIX_MAPPER_CAPABILITIES_URL="${TRIMMED_POSIX_MAPPER_URL}/capabilities"
 else
-    POSIX_MAPPER_CAPABILITIES_URL=`curl -SsL ${REGISTRY_URL}/resource-caps | grep ${POSIX_MAPPER_URI} | awk -F = '{print $2}' | xargs`
+    POSIX_MAPPER_CAPABILITIES_URL=`curl -kSsL ${REGISTRY_URL}/resource-caps | grep ${POSIX_MAPPER_URI} | awk -F = '{print $2}' | xargs`
 fi
 
 echo "Using POSIX Mapper service at ${POSIX_MAPPER_CAPABILITIES_URL}"
@@ -84,11 +84,11 @@ else
 
     # For the case of using the CADC client certificate.
     if [[ -f "${CADC_PROXY_CERT_FILE}" ]] ; then
-        curl -SsL -E ${CADC_PROXY_CERT_FILE} "${UID_URL}" | sed "s/^\([a-zA-Z0-9_\@\.\-]*\):\(.*\):::$/\1:\2::${ESCAPED_HOME}\/\1:\/sbin\/nologin/" >> "${PASSWD_FILE}"
-        curl -SsL -E ${CADC_PROXY_CERT_FILE} "${GID_URL}" >> "${GROUP_FILE}"
+        curl -kSsL -E ${CADC_PROXY_CERT_FILE} "${UID_URL}" | sed "s/^\([a-zA-Z0-9_\@\.\-]*\):\(.*\):::$/\1:\2::${ESCAPED_HOME}\/\1:\/sbin\/nologin/" >> "${PASSWD_FILE}"
+        curl -kSsL -E ${CADC_PROXY_CERT_FILE} "${GID_URL}" >> "${GROUP_FILE}"
     else
         TOKEN=`cat ${TOKEN_FILE}`
-        curl -SsL --header "${TOKEN_AUTHORIZATION_HEADER} ${TOKEN}" "${UID_URL}" | sed "s/^\([a-zA-Z0-9_\@\.\-]*\):\(.*\):::$/\1:\2::${ESCAPED_HOME}\/\1:\/sbin\/nologin/" >> "${PASSWD_FILE}"
-        curl -SsL --header "${TOKEN_AUTHORIZATION_HEADER} ${TOKEN}" "${GID_URL}" >> "${GROUP_FILE}"
+        curl -kSsL --header "${TOKEN_AUTHORIZATION_HEADER} ${TOKEN}" "${UID_URL}" | sed "s/^\([a-zA-Z0-9_\@\.\-]*\):\(.*\):::$/\1:\2::${ESCAPED_HOME}\/\1:\/sbin\/nologin/" >> "${PASSWD_FILE}"
+        curl -kSsL --header "${TOKEN_AUTHORIZATION_HEADER} ${TOKEN}" "${GID_URL}" >> "${GROUP_FILE}"
     fi
 fi

--- a/deployment/helm/skaha/launch-scripts/build-menu.sh
+++ b/deployment/helm/skaha/launch-scripts/build-menu.sh
@@ -1,7 +1,10 @@
 #!/bin/bash
 
 HOST=$1
-TOKEN=$(cat ${HOME}/.token/.skaha)
+
+# Callback token
+TOKEN="${DESKTOP_SESSION_APP_TOKEN}"
+
 ICON_DIR="/headless/.icons"
 STARTUP_DIR="/desktopstartup"
 SKAHA_DIR="$HOME/.local/skaha"
@@ -225,12 +228,12 @@ build_menu_item () {
 echo "[skaha] Start building menu."
 init
 create_merged_applications_menu
-if [ -e "${HOME}/.token/.skaha" ]; then
+if [ -z "${TOKEN}" ]; then
+  handle_error "[skaha] No credentials to call back to Skaha with."
+  exit 1
+else
   echo "token is used in build menu"
   curl_out=$(curl -s -k --header "x-auth-token-skaha:${TOKEN}" "https://${HOST}/skaha/${SKAHA_API_VERSION}/image?type=desktop-app")
-else
-  echo "[skaha] No credentials to call back to Skaha with."
-  exit 1
 fi
 if [[ $(echo ${curl_out} | jq '[.[] | .id | length] | add') == 0 ]]; then
   echo "[skaha] no desktop-app"

--- a/deployment/helm/skaha/launch-scripts/build-menu.sh
+++ b/deployment/helm/skaha/launch-scripts/build-menu.sh
@@ -228,13 +228,7 @@ build_menu_item () {
 echo "[skaha] Start building menu."
 init
 create_merged_applications_menu
-if [ -z "${TOKEN}" ]; then
-  handle_error "[skaha] No credentials to call back to Skaha with."
-  exit 1
-else
-  echo "token is used in build menu"
-  curl_out=$(curl -s -k --header "x-auth-token-skaha:${TOKEN}" "https://${HOST}/skaha/${SKAHA_API_VERSION}/image?type=desktop-app")
-fi
+curl_out=$(curl -s -k --header "x-auth-token-skaha:${TOKEN}" "https://${HOST}/skaha/${SKAHA_API_VERSION}/image?type=desktop-app")
 if [[ $(echo ${curl_out} | jq '[.[] | .id | length] | add') == 0 ]]; then
   echo "[skaha] no desktop-app"
   echo "${curl_out}"

--- a/deployment/helm/skaha/skaha-config/launch-carta.yaml
+++ b/deployment/helm/skaha/skaha-config/launch-carta.yaml
@@ -61,7 +61,7 @@ spec:
         command: ["/bin/sh", "-c"]
         args:
         - /skaha-system/skaha-carta.sh ${SKAHA_TLD} ${SKAHA_TLD}/projects
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         resources:
           requests:
             memory: "${software.requests.ram}"

--- a/deployment/helm/skaha/skaha-config/launch-contributed.yaml
+++ b/deployment/helm/skaha/skaha-config/launch-contributed.yaml
@@ -58,7 +58,7 @@ spec:
         - name: OMP_NUM_THREADS
           value: "${software.requests.cores}"
         image: ${software.imageid}
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         resources:
           requests:
             memory: "${software.requests.ram}"

--- a/deployment/helm/skaha/skaha-config/launch-desktop-app.yaml
+++ b/deployment/helm/skaha/skaha-config/launch-desktop-app.yaml
@@ -65,7 +65,7 @@ spec:
               - ALL
         image: "${software.imageid}"
         workingDir: "${SKAHA_TLD}/home/${skaha.userid}"
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         resources:
           requests:
             memory: "${software.requests.ram}"

--- a/deployment/helm/skaha/skaha-config/launch-desktop.yaml
+++ b/deployment/helm/skaha/skaha-config/launch-desktop.yaml
@@ -65,7 +65,7 @@ spec:
             drop:
               - ALL
         image: ${software.imageid}
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         resources:
           requests:
             memory: "1Gi"

--- a/deployment/helm/skaha/skaha-config/launch-desktop.yaml
+++ b/deployment/helm/skaha/skaha-config/launch-desktop.yaml
@@ -56,6 +56,8 @@ spec:
           value: "1"
         - name: SKAHA_API_VERSION
           value: "v0"  
+        - name: DESKTOP_SESSION_APP_TOKEN
+          value: "${software.desktop.app.token}"
         securityContext:
           privileged: false
           allowPrivilegeEscalation: false

--- a/deployment/helm/skaha/skaha-config/launch-headless.yaml
+++ b/deployment/helm/skaha/skaha-config/launch-headless.yaml
@@ -60,7 +60,7 @@ spec:
             drop:
               - ALL
         workingDir: "${SKAHA_TLD}/home/${skaha.userid}"
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         resources:
           requests:
             memory: "${software.requests.ram}"

--- a/deployment/helm/skaha/skaha-config/launch-notebook.yaml
+++ b/deployment/helm/skaha/skaha-config/launch-notebook.yaml
@@ -81,7 +81,7 @@ spec:
         command: ["/skaha-system/start-jupyterlab.sh"]
         args:
         - ${skaha.sessionid}
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         resources:
           requests:
             memory: "${software.requests.ram}"

--- a/skaha/VERSION
+++ b/skaha/VERSION
@@ -1,6 +1,6 @@
 ## deployable containers have a semantic and build tag
 # version tag: major.minor.patch
 # build version tag: timestamp
-VER=0.19.0
+VER=0.19.1
 TAGS="${VER} ${VER}-$(date -u +"%Y%m%dT%H%M%S")"
 unset VER

--- a/skaha/src/main/java/org/opencadc/skaha/SkahaAction.java
+++ b/skaha/src/main/java/org/opencadc/skaha/SkahaAction.java
@@ -74,7 +74,6 @@ import ca.nrc.cadc.auth.HttpPrincipal;
 import ca.nrc.cadc.auth.NotAuthenticatedException;
 import ca.nrc.cadc.auth.PosixPrincipal;
 import ca.nrc.cadc.cred.client.CredUtil;
-import ca.nrc.cadc.io.ResourceIterator;
 import ca.nrc.cadc.net.HttpGet;
 import ca.nrc.cadc.net.ResourceNotFoundException;
 import ca.nrc.cadc.reg.Standards;
@@ -87,7 +86,6 @@ import ca.nrc.cadc.util.StringUtil;
 import org.apache.log4j.Logger;
 import org.json.JSONArray;
 import org.json.JSONObject;
-import org.opencadc.auth.PosixGroup;
 import org.opencadc.auth.PosixMapperClient;
 import org.opencadc.gms.GroupURI;
 import org.opencadc.gms.IvoaGroupClient;
@@ -154,9 +152,7 @@ public abstract class SkahaAction extends RestAction {
 
 
     protected boolean skahaCallbackFlow = false;
-    protected String callbackSessionId = null;
     protected String callbackSupplementalGroups = null;
-    protected String xAuthTokenSkaha = null;
 
 
     public SkahaAction() {
@@ -282,10 +278,10 @@ public abstract class SkahaAction extends RestAction {
 
     private void initiateSkahaCallbackFlow(Subject currentSubject, URI skahaUsersUri) {
         skahaCallbackFlow = true;
-        xAuthTokenSkaha = syncInput.getHeader(X_AUTH_TOKEN_SKAHA);
+        final String xAuthTokenSkaha = syncInput.getHeader(X_AUTH_TOKEN_SKAHA);
         log.debug("x-auth-token-skaha header is " + xAuthTokenSkaha);
         try {
-            callbackSessionId = SkahaAction.getTokenTool().validateToken(xAuthTokenSkaha, skahaUsersUri, WriteGrant.class);
+            final String callbackSessionId = SkahaAction.getTokenTool().validateToken(xAuthTokenSkaha, skahaUsersUri, WriteGrant.class);
 
             final Session session = SessionDAO.getSession(null, callbackSessionId, skahaTld);
             this.posixPrincipal = session.getPosixPrincipal();

--- a/skaha/src/main/java/org/opencadc/skaha/session/Session.java
+++ b/skaha/src/main/java/org/opencadc/skaha/session/Session.java
@@ -84,7 +84,8 @@ public class Session {
     
     public static final String STATUS_TERMINATING = "Terminating";
     public static final String STATUS_SUCCEEDED = "Succeeded";
-    
+    public static final String STATUS_RUNNING = "Running";
+
     private final String id;
     private final String userid;
     private final String runAsUID;

--- a/skaha/src/main/java/org/opencadc/skaha/session/SessionAction.java
+++ b/skaha/src/main/java/org/opencadc/skaha/session/SessionAction.java
@@ -69,7 +69,6 @@ package org.opencadc.skaha.session;
 
 import ca.nrc.cadc.auth.AuthMethod;
 import ca.nrc.cadc.auth.AuthenticationUtil;
-import ca.nrc.cadc.auth.AuthorizationToken;
 import ca.nrc.cadc.auth.HttpPrincipal;
 import ca.nrc.cadc.net.HttpGet;
 import ca.nrc.cadc.net.ResourceNotFoundException;
@@ -80,7 +79,6 @@ import ca.nrc.cadc.util.StringUtil;
 import org.apache.log4j.Logger;
 import org.opencadc.skaha.K8SUtil;
 import org.opencadc.skaha.SkahaAction;
-import org.opencadc.skaha.utils.CommandExecutioner;
 
 import javax.security.auth.Subject;
 import java.io.*;
@@ -173,42 +171,14 @@ public abstract class SessionAction extends SkahaAction {
         return "https://" + host + "/session/contrib/" + sessionID + "/";
     }
 
-    private static String accessToken() throws IllegalStateException {
-        return AuthenticationUtil.getCurrentSubject()
-                                 .getPublicCredentials(AuthorizationToken.class).stream()
-                                 .filter(authorizationToken -> authorizationToken.getType().equalsIgnoreCase("bearer"))
-                                 .findFirst()
-                                 .map(AuthorizationToken::getCredentials)
-                                 .orElseThrow(IllegalStateException::new);
-    }
-
+    /**
+     * Currently only injects a Proxy Certificate.
+     */
     protected void injectCredentials() {
-        if (!injectProxyCertificate()) {
-            injectAccessToken();
-        }
+        injectProxyCertificate();
     }
 
-    private void injectAccessToken() {
-        log.debug("injectAccessToken()");
-        // inject a token if available
-        final int posixId = getUID();
-        try {
-            String userHomeDirectory = CommandExecutioner.createDirectoryIfNotExist(homedir, this.posixPrincipal.username);
-            CommandExecutioner.changeOwnership(userHomeDirectory, posixId, posixId);
-            String tokenDirectory = CommandExecutioner.createDirectoryIfNotExist(userHomeDirectory, ".token");
-            CommandExecutioner.changeOwnership(tokenDirectory, posixId, posixId);
-            String tokenFilePath = CommandExecutioner.createOrOverrideFile(tokenDirectory, ".access", SessionAction.accessToken());
-            CommandExecutioner.changeOwnership(tokenFilePath, posixId, posixId);
-            log.debug("injectAccessToken(): OK");
-        } catch (Exception exception) {
-            log.debug("failed to inject token: " + exception.getMessage(), exception);
-        }
-
-        log.debug("No API Token found");
-        log.debug("injectAPIToken(): UNSUCCESSFUL");
-    }
-
-    private boolean injectProxyCertificate() {
+    private void injectProxyCertificate() {
         log.debug("injectProxyCertificate()");
 
         // inject a delegated proxy certificate if available
@@ -239,18 +209,15 @@ public abstract class SessionAction extends SkahaAction {
 
                     injectFile(proxyCert, Path.of(homedir, this.posixPrincipal.username, ".ssl", "cadcproxy.pem").toString());
                     log.debug("injectProxyCertificate(): OK");
-
-                    return true;
                 }
             }
         } catch (NoSuchElementException noSuchElementException) {
             log.debug("Not using proxy certificates");
+            log.debug("injectProxyCertificate(): UNSUCCESSFUL");
         } catch (Exception e) {
             log.warn("failed to inject cert: " + e.getMessage(), e);
+            log.debug("injectProxyCertificate(): UNSUCCESSFUL");
         }
-
-        log.debug("injectProxyCertificate(): UNSUCCESSFUL");
-        return false;
     }
 
     protected String getImageName(String image) {


### PR DESCRIPTION
CADC-13580

- Token is no longer written to user’s home directory, but rather used in an environment variable to isolate per Desktop Session.  The Token is still needed as the Desktop calls back to the /image and /context endpoints.
- Cleaned up where it’s used, and the token is only generated for Desktop Sessions