### PR TITLE
Gms userinfo fix

### DIFF
--- a/deployment/helm/skaha/CHANGELOG.md
+++ b/deployment/helm/skaha/CHANGELOG.md
@@ -1,7 +1,10 @@
-# CHANGELOG for Skaha User Session API (Chart 0.6.0)
+# CHANGELOG for Skaha User Session API (Chart 0.7.1)
+
+## 2024.10.03 (0.7.1)
+- Small fix to ensure userinfo endpoint is obtained from the Identity Provider for applications using the StandardIdentityManager
 
 ## 2024.09.20 (0.6.0)
-- Feature to allow mounting volumes into user sessions.
+- Feature to allow mounting volumes into user sessions
 
 ## 2024.09.19 (0.5.1)
 - Fix to add `headlessPriorityGroup` and `headlessPriorityClass` configurations

--- a/deployment/helm/skaha/Chart.yaml
+++ b/deployment/helm/skaha/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.7.0
+version: 0.7.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "0.21.0"
+appVersion: "0.21.1"
 
 dependencies:
   - name: "redis"

--- a/deployment/helm/skaha/values.yaml
+++ b/deployment/helm/skaha/values.yaml
@@ -17,7 +17,7 @@ skahaWorkload:
 deployment:
   hostname: myhost.example.com  # Change this!
   skaha:
-    image: images.opencadc.org/platform/skaha:0.21.0
+    image: images.opencadc.org/platform/skaha:0.21.1
     imagePullPolicy: Always
   
     # Set the top-level-directory name that gets mounted at the root.

--- a/skaha/VERSION
+++ b/skaha/VERSION
@@ -1,6 +1,6 @@
 ## deployable containers have a semantic and build tag
 # version tag: major.minor.patch
 # build version tag: timestamp
-VER=0.21.0
+VER=0.21.1
 TAGS="${VER} ${VER}-$(date -u +"%Y%m%dT%H%M%S")"
 unset VER

--- a/skaha/build.gradle
+++ b/skaha/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     implementation 'org.opencadc:cadc-access-control:[1.1.23,)'
     implementation 'org.opencadc:cadc-access-control-identity:[1.1.0,)'
     implementation 'org.opencadc:cadc-cdp:[1.2,)'
-    implementation 'org.opencadc:cadc-gms:[1.0.12,2.0)'
+    implementation 'org.opencadc:cadc-gms:[1.0.14,2.0)'
     implementation 'org.opencadc:cadc-log:[1.2.1,1.3.0)'
     implementation 'org.opencadc:cadc-rest:[1.3.17,)'
     implementation 'org.opencadc:cadc-util:[1.9.7,2.0)'


### PR DESCRIPTION
Ensure the `/userinfo` endpoint is properly pulled from the OIDC Discovery document.  Requres `cadc-gms:1.0.14`.