### PR TITLE
Treafik api group fix

### DIFF
--- a/deployment/helm/README.md
+++ b/deployment/helm/README.md
@@ -57,6 +57,15 @@ secrets:
     default-certificate:
         tls.crt: <base64 encoded server certificate>
         tls.key: <base64 encoded server key>
+
+# Settings passed to Traefik.  The install flag is used by Helm to proceed to install Traefik or not.  If false, ensure v2.11.0 is at minimum installed.
+traefik:
+  install: true
+  tlsStore:
+    default:
+      defaultCertificate:
+        # See default-certificate secret(s) above
+        secretName: default-certificate
 ```
 
 ```bash
@@ -185,10 +194,6 @@ secrets:
 #     spec:
 #       hostPath:
 #         path: "/posixmapper/data"
-
-# An omission equals true, so set this explicitly to false as we already installed it.
-base:
-  install: false
 ```
 
 It is recommended to install into the `skaha-system` namespace, but not required.

--- a/deployment/helm/base/templates/general-user-clusterrole-rbac.yaml
+++ b/deployment/helm/base/templates/general-user-clusterrole-rbac.yaml
@@ -80,7 +80,7 @@ rules:
   resources: ["ingresses"]
   verbs: ["create", "get", "list", "watch", "update", "patch", "delete", "deletecollection"]
 # Traefik IngressRoute and Middleware
-- apiGroups: ["traefik.containo.us", "traefik.io"]
+- apiGroups: ["traefik.io"]
   resources: ["ingressroutes", "ingressroutetcps", "middlewares"]
   verbs: ["create", "get", "list", "watch", "update", "patch", "delete", "deletecollection"]
 # Allow users to protect their apps against unavailability with poddisruptionbudget (https://github.com/kubernetes/kubernetes/issues/50767)

--- a/deployment/k8s-config/kustomize/base/sshd/arc-sshd-ingress.yaml
+++ b/deployment/k8s-config/kustomize/base/sshd/arc-sshd-ingress.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: traefik.containo.us/v1alpha1
+apiVersion: traefik.io/v1alpha1
 kind: IngressRouteTCP
 metadata:
   name: arc-sshd-ingressroute


### PR DESCRIPTION
This PR applies to the remaining items in the `opencadc/science-platform` `deployment` folder.  The changes pertinent to `skaha` are complete in the `opencadc/deployments` repository, which is the new home for Helm charts.
https://github.com/opencadc/deployments/tree/main/helm/applications/skaha