### PR TITLE
CADC-13895: Firefly Session

### DIFF
--- a/skaha/build.gradle
+++ b/skaha/build.gradle
@@ -55,8 +55,7 @@ dependencies {
     implementation 'org.opencadc:cadc-vosi:[1.4.3,)'
     implementation 'org.opencadc:cadc-permissions:[0.3.4,2.0)'
     implementation 'redis.clients:jedis:[5.0.2,6.0.0)'
-
-    runtimeOnly 'org.opencadc:cadc-registry:[1.7.7,)'
+    implementation 'org.opencadc:cadc-registry:[1.7.7,)'
 
     testImplementation 'junit:junit:[4.13,)'
     testImplementation 'org.json:json:20231013'

--- a/skaha/src/main/java/org/opencadc/skaha/SessionType.java
+++ b/skaha/src/main/java/org/opencadc/skaha/SessionType.java
@@ -8,7 +8,8 @@ public enum SessionType {
     DESKTOP(true, true, "desktop"),
     NOTEBOOK(true, true, "notebook"),
     HEADLESS(false, false, "headless"),
-    DESKTOP_APP(false, false, "desktop-app");
+    DESKTOP_APP(false, false, "desktop-app"),
+    FIREFLY(true, true, "firefly");
 
     private final boolean supportsIngress;
     private final boolean supportsService;

--- a/skaha/src/main/java/org/opencadc/skaha/SkahaAction.java
+++ b/skaha/src/main/java/org/opencadc/skaha/SkahaAction.java
@@ -38,19 +38,19 @@
  *  OpenCADC is free software:           OpenCADC est un logiciel libre ;
  *  you can redistribute it and/or       vous pouvez le redistribuer ou le
  *  modify it under the terms of         modifier suivant les termes de
- *  the GNU Affero General Public        la “GNU Affero General Public
- *  License as published by the          License” telle que publiée
+ *  the GNU Affero General Public        la "GNU Affero General Public
+ *  License as published by the          License" telle que publiée
  *  Free Software Foundation,            par la Free Software Foundation
  *  either version 3 of the              : soit la version 3 de cette
  *  License, or (at your option)         licence, soit (à votre gré)
  *  any later version.                   toute version ultérieure.
  *
  *  OpenCADC is distributed in the       OpenCADC est distribué
- *  hope that it will be useful,         dans l’espoir qu’il vous
+ *  hope that it will be useful,         dans l'espoir qu'il vous
  *  but WITHOUT ANY WARRANTY;            sera utile, mais SANS AUCUNE
  *  without even the implied             GARANTIE : sans même la garantie
  *  warranty of MERCHANTABILITY          implicite de COMMERCIALISABILITÉ
- *  or FITNESS FOR A PARTICULAR          ni d’ADÉQUATION À UN OBJECTIF
+ *  or FITNESS FOR A PARTICULAR          ni d'ADÉQUATION À UN OBJECTIF
  *  PURPOSE.  See the GNU Affero         PARTICULIER. Consultez la Licence
  *  General Public License for           Générale Publique GNU Affero
  *  more details.                        pour plus de détails.
@@ -58,7 +58,7 @@
  *  You should have received             Vous devriez avoir reçu une
  *  a copy of the GNU Affero             copie de la Licence Générale
  *  General Public License along         Publique GNU Affero avec
- *  with OpenCADC.  If not, see          OpenCADC ; si ce n’est
+ *  with OpenCADC.  If not, see          OpenCADC ; si ce n'est
  *  <http://www.gnu.org/licenses/>.      pas le cas, consultez :
  *                                       <http://www.gnu.org/licenses/>.
  *
@@ -111,6 +111,7 @@ public abstract class SkahaAction extends RestAction {
     public static final String SESSION_TYPE_DESKTOP = "desktop";
     public static final String SESSION_TYPE_CONTRIB = "contributed";
     public static final String SESSION_TYPE_HEADLESS = "headless";
+    public static final String SESSION_TYPE_FIREFLY = "firefly";
     public static final String TYPE_DESKTOP_APP = "desktop-app";
     public static final String X_AUTH_TOKEN_SKAHA = "x-auth-token-skaha";
     private static final String X_REGISTRY_AUTH_HEADER = "x-skaha-registry-auth";
@@ -121,6 +122,7 @@ public abstract class SkahaAction extends RestAction {
             SESSION_TYPE_DESKTOP,
             SESSION_TYPE_CONTRIB,
             SESSION_TYPE_HEADLESS,
+            SESSION_TYPE_FIREFLY,
             TYPE_DESKTOP_APP);
     protected final PosixMapperConfiguration posixMapperConfiguration;
     public List<String> harborHosts;

--- a/skaha/src/main/java/org/opencadc/skaha/session/SessionDAO.java
+++ b/skaha/src/main/java/org/opencadc/skaha/session/SessionDAO.java
@@ -358,6 +358,8 @@ public class SessionDAO {
         } else if (SessionAction.SESSION_TYPE_CONTRIB.equals(type)) {
             connectURL =
                     SessionURLBuilder.contributedSession(sessionHostName, id).build();
+        } else if (SessionAction.SESSION_TYPE_FIREFLY.equals(type)) {
+            connectURL = SessionURLBuilder.fireflySession(sessionHostName, id).build();
         } else {
             connectURL = "not-applicable";
         }

--- a/skaha/src/main/java/org/opencadc/skaha/session/SessionURLBuilder.java
+++ b/skaha/src/main/java/org/opencadc/skaha/session/SessionURLBuilder.java
@@ -68,6 +68,17 @@ public abstract class SessionURLBuilder {
     }
 
     /**
+     * Create a builder to a Firefly session.
+     *
+     * @param host The host name.
+     * @param sessionID The session ID.
+     * @return FireflySessionURLBuilder instance. Never null.
+     */
+    static FireflySessionURLBuilder fireflySession(final String host, final String sessionID) {
+        return new FireflySessionURLBuilder(host, sessionID);
+    }
+
+    /**
      * Abstract method to build the URL.
      *
      * @return The URL string. Never null.
@@ -252,6 +263,39 @@ public abstract class SessionURLBuilder {
                     .setScheme("https")
                     .setHost(this.host)
                     .setPathSegments("session", "contrib", this.sessionID, "")
+                    .build()
+                    .toString();
+        }
+    }
+
+    /** Construct a URL for a Firefly session. Used to redirect the end user to the Firefly viewer. */
+    static final class FireflySessionURLBuilder extends SessionURLBuilder {
+        /**
+         * Constructor.
+         *
+         * @param host The host name.
+         * @param sessionID The session ID.
+         */
+        FireflySessionURLBuilder(String host, String sessionID) {
+            super(host, sessionID);
+        }
+
+        /**
+         * Build the URL for a Firefly session. Example output: <code>
+         *     https://host.example.org/session/firefly/8675309/firefly/
+         * </code>
+         *
+         * @return URL string in format <code>
+         *     https://${host}/session/firefly/${sessionID}/firefly/
+         *     </code>
+         * @throws URISyntaxException If the URI cannot be created.
+         */
+        @Override
+        String build() throws URISyntaxException {
+            return new URIBuilder()
+                    .setScheme("https")
+                    .setHost(this.host)
+                    .setPathSegments("session", "firefly", this.sessionID, "firefly", "")
                     .build()
                     .toString();
         }

--- a/skaha/src/main/java/org/opencadc/skaha/utils/CommonUtils.java
+++ b/skaha/src/main/java/org/opencadc/skaha/utils/CommonUtils.java
@@ -24,10 +24,10 @@ public class CommonUtils {
      * Obtain the first configured Service URI for the given base standard ID.
      *
      * @param baseStandardID The URI to lookup.
-     * @return A single URI (first matching).  Never null.
+     * @return A single URI (first matching). Never null.
      */
     public static URI firstLocalServiceURI(final URI baseStandardID) {
-        final Set<URI> serviceURIs = new LocalAuthority().getServiceURIs(baseStandardID);
+        final Set<URI> serviceURIs = new LocalAuthority().getResourceIDs(baseStandardID);
         return serviceURIs.stream().findFirst().orElseThrow(IllegalStateException::new);
     }
 }

--- a/skaha/src/test/java/org/opencadc/skaha/session/SessionURLBuilderTest.java
+++ b/skaha/src/test/java/org/opencadc/skaha/session/SessionURLBuilderTest.java
@@ -100,12 +100,10 @@ public class SessionURLBuilderTest {
 
     @Test
     public void testFireflySession() throws Exception {
-        final String fireflyURL = SessionURLBuilder.fireflySession("host.example.org", "8675309").build();
+        final String fireflyURL =
+                SessionURLBuilder.fireflySession("host.example.org", "8675309").build();
 
-        Assert.assertEquals(
-                "Wrong URL",
-                "https://host.example.org/session/firefly/8675309/firefly/",
-                fireflyURL);
+        Assert.assertEquals("Wrong URL", "https://host.example.org/session/firefly/8675309/firefly/", fireflyURL);
 
         try {
             SessionURLBuilder.fireflySession(null, "8675309").build();

--- a/skaha/src/test/java/org/opencadc/skaha/session/SessionURLBuilderTest.java
+++ b/skaha/src/test/java/org/opencadc/skaha/session/SessionURLBuilderTest.java
@@ -97,4 +97,21 @@ public class SessionURLBuilderTest {
             // Expected
         }
     }
+
+    @Test
+    public void testFireflySession() throws Exception {
+        final String fireflyURL = SessionURLBuilder.fireflySession("host.example.org", "8675309").build();
+
+        Assert.assertEquals(
+                "Wrong URL",
+                "https://host.example.org/session/firefly/8675309/firefly/",
+                fireflyURL);
+
+        try {
+            SessionURLBuilder.fireflySession(null, "8675309").build();
+            Assert.fail("Expected NullPointerException");
+        } catch (NullPointerException e) {
+            // Expected
+        }
+    }
 }


### PR DESCRIPTION
Introduces support for a new session type, "Firefly," across various components of the `skaha` project. The changes include updates to session type definitions, URL building logic, and corresponding unit tests to ensure proper functionality.