### PR TITLE
fix: fix for properly querying sessions from status

### DIFF
--- a/skaha/src/main/java/org/opencadc/skaha/K8SUtil.java
+++ b/skaha/src/main/java/org/opencadc/skaha/K8SUtil.java
@@ -245,11 +245,20 @@ public class K8SUtil {
         private static final String SKAHA_EXPERIMENTAL_FEATURES_PREFIX = "SKAHA_EXPERIMENTAL_FEATURE_GATES";
         private final Map<String, Boolean> featureGates = new HashMap<>();
 
+        /**
+         * Check if the given feature gate is enabled. This will not enforce the existence of the feature gate, so if it
+         * is not defined, it will return false.
+         *
+         * @param featureGateName The name of the feature gate to check.
+         * @return True if the feature gate exists and is enabled, false otherwise.
+         */
         public boolean isEnabled(final String featureGateName) {
             if (this.featureGates.containsKey(featureGateName)) {
                 return this.featureGates.get(featureGateName);
+            } else {
+                LOGGER.warn(String.format("Feature gate %s not found.  Returning false.", featureGateName));
+                return false;
             }
-            throw new IllegalArgumentException("Feature gate " + featureGateName + " not found.");
         }
 
         @Override

--- a/skaha/src/main/java/org/opencadc/skaha/session/PostAction.java
+++ b/skaha/src/main/java/org/opencadc/skaha/session/PostAction.java
@@ -88,6 +88,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 import javax.security.auth.Subject;
 import org.apache.log4j.Logger;
+import org.jetbrains.annotations.NotNull;
 import org.opencadc.auth.PosixGroup;
 import org.opencadc.gms.GroupURI;
 import org.opencadc.permissions.WriteGrant;
@@ -437,24 +438,27 @@ public class PostAction extends SessionAction {
         throw new IllegalArgumentException("image not in a trusted repository");
     }
 
-    public void checkExistingSessions(SessionType type) throws Exception {
-        // multiple
+    private void checkExistingSessions(final SessionType type) throws Exception {
+        checkExistingSessions(type, SessionDAO.getUserSessions(this.posixPrincipal.username, null, true));
+    }
+
+    /**
+     * Check the count of existing non-headless and non desktop-app sessions for the user.
+     *
+     * @param type The type of desired session to ensure not headless.
+     * @param sessions The list of existing Session objects for the user.
+     */
+    void checkExistingSessions(@NotNull final SessionType type, @NotNull final List<Session> sessions) {
         if (!type.isHeadless()) {
-            final List<Session> sessions = SessionDAO.getUserSessions(this.posixPrincipal.username, null, true);
-            int count = 0;
-            for (Session session : sessions) {
-                log.debug("checking session: " + session);
-                if (!TYPE_DESKTOP_APP.equals(session.getType())) {
-                    final String status = session.getStatus();
-                    if (!(status.equalsIgnoreCase(Session.STATUS_TERMINATING)
-                            || status.equalsIgnoreCase(Session.STATUS_COMPLETED))) {
-                        count++;
-                    }
-                }
-            }
+            final long count = sessions.stream()
+                    .filter(session -> !TYPE_DESKTOP_APP.equals(session.getType()))
+                    .filter(session -> session.getStatus().equalsIgnoreCase(Session.STATUS_RUNNING)
+                            || session.getStatus().equalsIgnoreCase(Session.STATUS_PENDING))
+                    .count();
+
             log.debug("active interactive sessions: " + count);
             if (count >= maxUserSessions) {
-                throw new IllegalArgumentException("User " + posixPrincipal.username + " has reached the maximum of "
+                throw new IllegalArgumentException("User " + getUsername() + " has reached the maximum of "
                         + maxUserSessions + " active sessions.");
             }
         }

--- a/skaha/src/main/java/org/opencadc/skaha/session/PostAction.java
+++ b/skaha/src/main/java/org/opencadc/skaha/session/PostAction.java
@@ -88,7 +88,6 @@ import java.util.*;
 import java.util.stream.Collectors;
 import javax.security.auth.Subject;
 import org.apache.log4j.Logger;
-import org.jetbrains.annotations.NotNull;
 import org.opencadc.auth.PosixGroup;
 import org.opencadc.gms.GroupURI;
 import org.opencadc.permissions.WriteGrant;
@@ -448,7 +447,10 @@ public class PostAction extends SessionAction {
      * @param type The type of desired session to ensure not headless.
      * @param sessions The list of existing Session objects for the user.
      */
-    void checkExistingSessions(@NotNull final SessionType type, @NotNull final List<Session> sessions) {
+    void checkExistingSessions(final SessionType type, final List<Session> sessions) {
+        Objects.requireNonNull(type, "type must not be null");
+        Objects.requireNonNull(sessions, "sessions must not be null");
+
         if (!type.isHeadless()) {
             final long count = sessions.stream()
                     .filter(session -> !TYPE_DESKTOP_APP.equals(session.getType()))

--- a/skaha/src/main/java/org/opencadc/skaha/session/SessionType.java
+++ b/skaha/src/main/java/org/opencadc/skaha/session/SessionType.java
@@ -14,7 +14,7 @@ public enum SessionType {
 
     private final boolean supportsIngress;
     private final boolean supportsService;
-    final String applicationName;
+    public final String applicationName;
 
     SessionType(final boolean supportsIngress, final boolean supportsService, final String applicationName) {
         this.supportsIngress = supportsIngress;

--- a/skaha/src/test/java/org/opencadc/skaha/utils/TestUtils.java
+++ b/skaha/src/test/java/org/opencadc/skaha/utils/TestUtils.java
@@ -1,34 +1,24 @@
 package org.opencadc.skaha.utils;
 
-import java.lang.reflect.Field;
-import java.util.Map;
+import org.jetbrains.annotations.NotNull;
+import org.opencadc.skaha.session.Session;
+import org.opencadc.skaha.session.SessionType;
 
 public class TestUtils {
-    public static <T> void set(T object, String propertyName, Object value) {
-        set(object, object.getClass(), propertyName, value);
-    }
-
-    public static <T> void set(T object, Class<?> className, String propertyName, Object value) {
-        try {
-            // Get the field by name
-            Field field = className.getDeclaredField(propertyName);
-            // Make the field accessible if it's private
-            field.setAccessible(true);
-            // Set the value of the field
-            field.set(object, value);
-        } catch (NoSuchFieldException e) {
-            System.err.println("No such field: " + propertyName);
-        } catch (IllegalAccessException e) {
-            System.err.println("Cannot access field: " + propertyName);
-        }
-    }
-
-    public static void setEnv(String key, String value) throws Exception {
-        Map<String, String> env = System.getenv();
-        Class<?> clazz = env.getClass();
-        Field field = clazz.getDeclaredField("m");
-        field.setAccessible(true);
-        Map<String, String> writableEnv = (Map<String, String>) field.get(env);
-        writableEnv.put(key, value);
+    public static Session createSession(
+            @NotNull final String id, @NotNull final SessionType type, @NotNull final String status) {
+        return new Session(
+                id,
+                "owner",
+                "88",
+                "88",
+                new Integer[0],
+                "example.org/image",
+                type.applicationName,
+                status,
+                "name-" + id,
+                null,
+                "https://example.org/connect",
+                null);
     }
 }


### PR DESCRIPTION
# Description
On Session create, there is a check for existing sessions to ensure only the allotted count is allowed.  Part of that is omitting any Sessions that are *not* `Running` or `Pending`.  Ensure that's the case.

# Changes
- Don't check for unwanted states, only the one that _are_ important
- Small fix for checking for a feature flag that doesn't exist