### PR TITLE
fix: add interactive view and remove running instances

### DIFF
--- a/skaha/src/main/java/org/opencadc/skaha/session/SessionAction.java
+++ b/skaha/src/main/java/org/opencadc/skaha/session/SessionAction.java
@@ -99,6 +99,7 @@ public abstract class SessionAction extends SkahaAction {
     protected static final String SESSION_VIEW_EVENTS = "events";
     protected static final String SESSION_VIEW_LOGS = "logs";
     protected static final String SESSION_VIEW_STATS = "stats";
+    protected static final String SESSION_VIEW_INTERACTIVE = "interactive";
     protected static final String NONE = "<none>";
 
     private static final Logger log = Logger.getLogger(SessionAction.class);
@@ -302,6 +303,10 @@ public abstract class SessionAction extends SkahaAction {
 
     public Session getSession(String forUserID, String sessionID) throws Exception {
         return SessionDAO.getSession(forUserID, sessionID);
+    }
+
+    List<Session> getInteractiveSessions(final String forUserID) throws Exception {
+        return SessionDAO.getUserSessions(forUserID, null, true);
     }
 
     List<Session> getAllSessions(final String forUserID) throws Exception {

--- a/skaha/src/main/java/org/opencadc/skaha/session/SessionDAO.java
+++ b/skaha/src/main/java/org/opencadc/skaha/session/SessionDAO.java
@@ -161,7 +161,7 @@ public class SessionDAO {
 
         final BatchV1Api api = new BatchV1Api(client);
         final BatchV1Api.APIlistNamespacedJobRequest jobListRequest =
-                api.listNamespacedJob(K8SUtil.getWorkloadNamespace()).allowWatchBookmarks(Boolean.TRUE);
+                api.listNamespacedJob(K8SUtil.getWorkloadNamespace());
 
         if (StringUtil.hasLength(forUserID)) {
             labelSelectors.add("canfar-net-userid=" + forUserID);

--- a/skaha/src/test/java/org/opencadc/skaha/session/GetActionTests.java
+++ b/skaha/src/test/java/org/opencadc/skaha/session/GetActionTests.java
@@ -206,7 +206,7 @@ public class GetActionTests {
     static class TestGetAction extends GetAction {
 
         @Override
-        public List<Session> getAllSessions(String forUserID) throws Exception {
+        public List<Session> getAllSessions(String forUserID) {
             // A bit of a hack to emulate the state.
             this.skahaTld = "/cavern-vospace";
 


### PR DESCRIPTION
Add `view=interactive` to filter interactive sessions for the Portal
Remove querying running instances from the portal