### PR TITLE
Limit range defaults

### DIFF
--- a/image-cache/Dockerfile
+++ b/image-cache/Dockerfile
@@ -1,4 +1,4 @@
-FROM redis:7-alpine
+FROM redis:8-alpine
 
 RUN apk --no-cache add jq curl
 VOLUME /config

--- a/skaha/build.gradle
+++ b/skaha/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     // Used to merge YAML sections to fully configure Job files.
     // Ensure the Snake YAML version is 2.5 to prevent unnecessary logging of WARNING messages.
     implementation 'org.yaml:snakeyaml:2.5'
-    implementation 'io.kubernetes:client-java:24.0.0'
+    implementation 'io.kubernetes:client-java:25.0.0'
 
     // Used to read configuration from the environment and property files.
     implementation 'org.apache.commons:commons-configuration2:[2.11.0,3.0.0)'
@@ -69,10 +69,10 @@ dependencies {
     implementation 'redis.clients:jedis:[5.0.2,6.0.0)'
 
     // JSON schema validator
-    testImplementation 'com.networknt:json-schema-validator:1.5.9'
+    testImplementation 'com.github.erosb:everit-json-schema:1.14.6'
     testImplementation 'junit:junit:[4.13,)'
-    testImplementation 'org.json:json:20250517'
-    testImplementation 'org.mockito:mockito-core:5.12.0'
+    testImplementation 'org.json:json:20251224'
+    testImplementation 'org.mockito:mockito-core:5.21.0'
 }
 
 spotless {
@@ -93,7 +93,7 @@ spotless {
     // Checks for javadoc formatting
     checkstyle {
       // Point to the same checkstyle.xml file as the checkstyle task
-      configFile file("$rootDir/checkstyle.xml")
+      configFile file("${projectDir}/checkstyle.xml")
     }
   }
 }
@@ -110,12 +110,12 @@ check.dependsOn jacocoTestReport
 
 // Create JavaDoc
 javadoc {
-    destinationDir = file("${buildDir}/docs/javadoc")
+    destinationDir = file("${layout.buildDirectory}/docs/javadoc")
 }
 
 // Create Java Documentation using Dokka for Github Markdown and HTML
 tasks.dokkaGfm.configure {
-    outputDirectory.set(file("${buildDir}/docs/dokka/gfm"))
+    outputDirectory.set(file("${layout.buildDirectory}/docs/dokka/gfm"))
     dokkaSourceSets {
         register("main") {
             sourceRoots.from(file("src/main/java"))
@@ -123,7 +123,7 @@ tasks.dokkaGfm.configure {
     }
 }
 tasks.dokkaHtml.configure {
-    outputDirectory.set(file("${buildDir}/docs/dokka/html"))
+    outputDirectory.set(file("${layout.buildDirectory}/docs/dokka/html"))
     dokkaSourceSets {
         register("main") {
             sourceRoots.from(file("src/main/java"))

--- a/skaha/opencadc.gradle
+++ b/skaha/opencadc.gradle
@@ -1,34 +1,31 @@
+sourceSets {
+    intTest {
+        java {
+            compileClasspath += main.output + test.output
+            runtimeClasspath += main.output + test.output
+        }
+        resources {
+            srcDirs = ['src/intTest/resources']
+        }
+    }
+}
+
 configurations {
     // Configuration for integration tests
     intTestRuntime.extendsFrom testRuntime
     intTestImplementation.extendsFrom testImplementation
 }
 
-sourceSets {
-    test {
-        resources.srcDirs += 'src/test/resources'
-    }
-    intTest {
-        java {
-            compileClasspath += main.output + test.output
-            runtimeClasspath += main.output + test.output
-        }
-        resources.srcDir file('src/intTest/resources')
-        resources.srcDirs += new File(System.getenv('A') + '/test-certificates/')
-    }
-}
-
-tasks.withType(Test) {
+tasks.withType(Test).configureEach {
     // reset the report destinations so that intTests go to their own page
-    //reports.html.destination = file("${reporting.baseDir}/${name}")
-    reports.html.destination = file(reporting.baseDir.getAbsolutePath() + '/' + name)
+    reports.html.outputLocation = layout.buildDirectory.dir("reports/" + name)
 
     // Assign all Java system properties from
     // the command line to the tests
-    systemProperties System.properties
+    systemProperties System.properties as Map<String, ? extends Object>
 }
 
-task intTest(type: Test) {
+tasks.register('intTest', Test) {
     // set the configuration context
     testClassesDirs = sourceSets.intTest.output.classesDirs
     classpath = sourceSets.intTest.runtimeClasspath

--- a/skaha/src/main/java/org/opencadc/skaha/K8SUtil.java
+++ b/skaha/src/main/java/org/opencadc/skaha/K8SUtil.java
@@ -84,6 +84,9 @@ public class K8SUtil {
 
     static final String SKAHA_WORKER_NODE_LABEL_SELECTOR_ENV = "SKAHA_WORKER_NODE_LABEL_SELECTOR";
 
+    // Environment variable to enable session limit range feature.
+    public static final String SKAHA_SESSION_LIMIT_RANGE_ENABLED_ENV = "SKAHA_SESSION_LIMIT_RANGE_ENABLED";
+
     // Environment variable for POSIX mapper cache TTL in seconds before it expires.
     static final String SKAHA_POSIX_MAPPER_CACHE_TTL_SECONDS_ENV = "SKAHA_POSIX_MAPPER_CACHE_TTL_SECONDS";
     static final long SKAHA_POSIX_MAPPER_CACHE_TTL_SECONDS_DEFAULT = 86400L; // 1 day
@@ -265,20 +268,20 @@ public class K8SUtil {
     }
 
     /**
-     * Extract the major version number from a docker image tag.
+     * Check if the session limit range feature is enabled via the environment variable.
      *
-     * @param image The docker image string, e.g. "myrepo/myimage:1.2.3"
+     * @return True if enabled, false otherwise.
      */
-    public static Integer getMajorImageVersion(final String image) {
-        final String imageVersion = image.substring(image.lastIndexOf(":") + 1);
-
-        try {
-            return Integer.parseInt(imageVersion.substring(0, 1));
-        } catch (NumberFormatException nfe) {
-            return null;
-        }
+    public static boolean isSessionLimitRangeEnabled() {
+        final String enabledValue = System.getenv(K8SUtil.SKAHA_SESSION_LIMIT_RANGE_ENABLED_ENV);
+        return Boolean.parseBoolean(enabledValue);
     }
 
+    /**
+     * Obtain the experimental features configuration from the environment.
+     *
+     * @return ExperimentalFeatures instance. Never null.
+     */
     public static ExperimentalFeatures getExperimentalFeatures() {
         return ExperimentalFeatures.fromEnv();
     }

--- a/skaha/src/main/java/org/opencadc/skaha/context/ResourceContextDAO.java
+++ b/skaha/src/main/java/org/opencadc/skaha/context/ResourceContextDAO.java
@@ -23,14 +23,14 @@ public class ResourceContextDAO {
                     api.listNamespacedLimitRange(K8SUtil.getWorkloadNamespace()).execute();
             Objects.requireNonNull(
                     limitRangeList,
-                    "Limit range list cannot be null if " + ResourceContexts.SESSION_LIMIT_RANGE_FEATURE_GATE
+                    "Limit range list cannot be null if " + K8SUtil.SKAHA_SESSION_LIMIT_RANGE_ENABLED_ENV
                             + " feature gate declared.");
 
             if (limitRangeList.getItems().isEmpty()) {
                 throw new IllegalStateException("No limit ranges found in namespace: "
                         + K8SUtil.getWorkloadNamespace()
                         + ". A limit range must be defined if the "
-                        + ResourceContexts.SESSION_LIMIT_RANGE_FEATURE_GATE
+                        + K8SUtil.SKAHA_SESSION_LIMIT_RANGE_ENABLED_ENV
                         + " feature gate is declared.");
             }
 

--- a/skaha/src/main/java/org/opencadc/skaha/context/ResourceContexts.java
+++ b/skaha/src/main/java/org/opencadc/skaha/context/ResourceContexts.java
@@ -88,7 +88,6 @@ import org.opencadc.skaha.K8SUtil;
 public class ResourceContexts {
 
     private static final Logger log = Logger.getLogger(ResourceContexts.class);
-    static final String SESSION_LIMIT_RANGE_FEATURE_GATE = "sessionLimitRange";
     private static final String SESSION_LIMIT_FILE_NAME = "k8s-resources.json";
 
     private final Integer defaultRequestCores;
@@ -139,9 +138,7 @@ public class ResourceContexts {
      */
     @NotNull static Reader getJSONReader() {
         try {
-            final K8SUtil.ExperimentalFeatures experimentalFeatures = K8SUtil.getExperimentalFeatures();
-            final boolean sessionLimitRangeEnabled =
-                    experimentalFeatures.isEnabled(ResourceContexts.SESSION_LIMIT_RANGE_FEATURE_GATE);
+            final boolean sessionLimitRangeEnabled = K8SUtil.isSessionLimitRangeEnabled();
             if (sessionLimitRangeEnabled) {
                 final LimitRangeResourceContext limitRangeResourceContext = new LimitRangeResourceContext();
                 try (final OutputStream outputStream = new ByteArrayOutputStream()) {

--- a/skaha/src/main/java/org/opencadc/skaha/context/ResourceContexts.java
+++ b/skaha/src/main/java/org/opencadc/skaha/context/ResourceContexts.java
@@ -179,6 +179,10 @@ public class ResourceContexts {
         return this.availableCores.contains(coreCount);
     }
 
+    public boolean isRAMAmountAvailable(final Integer ramAmount) {
+        return this.availableRAM.contains(ramAmount);
+    }
+
     public Integer getDefaultRequestRAM() {
         return defaultRequestRAM;
     }

--- a/skaha/src/main/java/org/opencadc/skaha/session/FlexResourceRequestConfiguration.java
+++ b/skaha/src/main/java/org/opencadc/skaha/session/FlexResourceRequestConfiguration.java
@@ -25,8 +25,10 @@ public class FlexResourceRequestConfiguration {
         }
 
         final String expectedTypeCase = sessionType.toUpperCase();
+
         final String cpuEnvVar = String.format(FLEX_RESOURCE_REQUEST_CPU_ENV_VAR, expectedTypeCase);
         final String memoryEnvVar = String.format(FLEX_RESOURCE_REQUEST_MEMORY_ENV_VAR_TEMPLATE, expectedTypeCase);
+
         final String cpu = env.get(cpuEnvVar);
         final String memory = env.get(memoryEnvVar);
         return new FlexResourceRequestConfiguration(cpu, memory);

--- a/skaha/src/main/java/org/opencadc/skaha/session/FlexResourceRequestConfiguration.java
+++ b/skaha/src/main/java/org/opencadc/skaha/session/FlexResourceRequestConfiguration.java
@@ -1,0 +1,59 @@
+package org.opencadc.skaha.session;
+
+import ca.nrc.cadc.util.StringUtil;
+import java.util.Objects;
+
+/** Configuration for flexible resource requests based on session type. */
+public class FlexResourceRequestConfiguration {
+    public static final String FLEX_RESOURCE_REQUEST_MEMORY_ENV_VAR_TEMPLATE = "SKAHA_FLEX_RESOURCE_REQUEST_%s_MEMORY";
+    public static final String FLEX_RESOURCE_REQUEST_CPU_ENV_VAR = "SKAHA_FLEX_RESOURCE_REQUEST_%s_CPU";
+
+    private final String cpu;
+    private final String memory;
+
+    static FlexResourceRequestConfiguration fromSessionType(final String sessionType) {
+        return FlexResourceRequestConfiguration.fromSessionType(sessionType, System.getenv());
+    }
+
+    static FlexResourceRequestConfiguration fromSessionType(
+            final String sessionType, final java.util.Map<String, String> env) {
+
+        Objects.requireNonNull(env, "Environment containing configuration keys must be provided.");
+
+        if (!StringUtil.hasText(sessionType)) {
+            throw new IllegalArgumentException("Session type must be provided.");
+        }
+
+        final String expectedTypeCase = sessionType.toUpperCase();
+        final String cpuEnvVar = String.format(FLEX_RESOURCE_REQUEST_CPU_ENV_VAR, expectedTypeCase);
+        final String memoryEnvVar = String.format(FLEX_RESOURCE_REQUEST_MEMORY_ENV_VAR_TEMPLATE, expectedTypeCase);
+        final String cpu = env.get(cpuEnvVar);
+        final String memory = env.get(memoryEnvVar);
+        return new FlexResourceRequestConfiguration(cpu, memory);
+    }
+
+    FlexResourceRequestConfiguration(final String cpu, final String memory) {
+        this.cpu = cpu;
+        this.memory = memory;
+    }
+
+    /**
+     * Get the CPU value, falling back to the default if not set.
+     *
+     * @param defaultCPU The default CPU value to use if none is set.
+     * @return double representing the CPU Core count value.
+     */
+    public double getCPU(final double defaultCPU) {
+        return StringUtil.hasText(this.cpu) ? Double.parseDouble(this.cpu) : defaultCPU;
+    }
+
+    /**
+     * Get the Memory value, falling back to the default if not set.
+     *
+     * @param defaultMemory The default Memory value to use if none is set.
+     * @return double representing the Memory value in GiB.
+     */
+    public double getMemory(final double defaultMemory) {
+        return StringUtil.hasText(this.memory) ? Double.parseDouble(this.memory) : defaultMemory;
+    }
+}

--- a/skaha/src/main/java/org/opencadc/skaha/session/SessionAction.java
+++ b/skaha/src/main/java/org/opencadc/skaha/session/SessionAction.java
@@ -68,7 +68,9 @@
 package org.opencadc.skaha.session;
 
 import ca.nrc.cadc.net.ResourceNotFoundException;
+import ca.nrc.cadc.rest.SyncInput;
 import ca.nrc.cadc.util.StringUtil;
+import jakarta.annotation.Nullable;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
@@ -269,5 +271,14 @@ public abstract class SessionAction extends SkahaAction {
                 .outputFormat("custom-columns=UID:.metadata.uid,EXPIRY:.spec.activeDeadlineSeconds");
 
         return getSessionJobCmd.build();
+    }
+
+    /**
+     * Obtain the current requested session type from the input parameters.
+     *
+     * @return String representing the requested session type. Possibly null.
+     */
+    @Nullable protected static String getRequestedSessionType(final SyncInput syncInput) {
+        return syncInput.getParameter("type");
     }
 }

--- a/skaha/src/main/java/org/opencadc/skaha/session/SessionBuilder.java
+++ b/skaha/src/main/java/org/opencadc/skaha/session/SessionBuilder.java
@@ -175,7 +175,6 @@ class SessionBuilder {
                         K8SUtil.getSessionsHostName(),
                         SessionType.fromApplicationStringType(this.type),
                         this.id,
-                        this.image,
                         userStorageConfiguration.homeBaseDirectory.toString(),
                         this.userID);
             } catch (URISyntaxException e) {

--- a/skaha/src/main/java/org/opencadc/skaha/session/SessionDAO.java
+++ b/skaha/src/main/java/org/opencadc/skaha/session/SessionDAO.java
@@ -254,7 +254,6 @@ public class SessionDAO {
             final String sessionHostName,
             final SessionType type,
             final String id,
-            final String image,
             final String absoluteHomeDirectory,
             final String userid)
             throws URISyntaxException {
@@ -263,13 +262,7 @@ public class SessionDAO {
         if (SessionType.DESKTOP == type) {
             connectURL = SessionURLBuilder.vncSession(sessionHostName, id).build();
         } else if (SessionType.CARTA == type) {
-            final String imageVersion = image.substring(image.lastIndexOf(":") + 1);
-            final Integer majorVersion = K8SUtil.getMajorImageVersion(image);
-
-            connectURL = SessionURLBuilder.cartaSession(sessionHostName, id)
-                    .withAlternateSocket(imageVersion.equalsIgnoreCase("1.4"))
-                    .withVersion5Path(majorVersion != null && majorVersion >= 5)
-                    .build();
+            connectURL = SessionURLBuilder.cartaSession(sessionHostName, id).build();
         } else if (SessionType.NOTEBOOK == type) {
             connectURL = SessionURLBuilder.notebookSession(sessionHostName, id)
                     .withAbsoluteHomeDirectory(absoluteHomeDirectory)

--- a/skaha/src/main/java/org/opencadc/skaha/session/SessionType.java
+++ b/skaha/src/main/java/org/opencadc/skaha/session/SessionType.java
@@ -38,28 +38,22 @@ public enum SessionType {
         throw new IllegalArgumentException("Invalid session type: " + applicationStringType);
     }
 
-    public Path getIngressConfigPath(final boolean isLegacyCARTA) {
+    public Path getIngressConfigPath() {
         return Path.of(String.format(
-                "%s/config/ingress-%s%s.yaml",
-                K8SUtil.getWorkingDirectory(),
-                this.name().toLowerCase(),
-                (isLegacyCARTA && this == CARTA) ? "-legacy" : ""));
+                "%s/config/ingress-%s.yaml",
+                K8SUtil.getWorkingDirectory(), this.name().toLowerCase()));
     }
 
-    public Path getServiceConfigPath(final boolean isLegacyCARTA) {
+    public Path getServiceConfigPath() {
         return Path.of(String.format(
-                "%s/config/service-%s%s.yaml",
-                K8SUtil.getWorkingDirectory(),
-                this.name().toLowerCase(),
-                (isLegacyCARTA && this == CARTA) ? "-legacy" : ""));
+                "%s/config/service-%s.yaml",
+                K8SUtil.getWorkingDirectory(), this.name().toLowerCase()));
     }
 
-    public Path getJobConfigPath(final boolean isLegacyCARTA) {
+    public Path getJobConfigPath() {
         return Path.of(String.format(
-                "%s/config/launch-%s%s.yaml",
-                K8SUtil.getWorkingDirectory(),
-                this.name().toLowerCase(),
-                (isLegacyCARTA && this == CARTA) ? "-legacy" : ""));
+                "%s/config/launch-%s.yaml",
+                K8SUtil.getWorkingDirectory(), this.name().toLowerCase()));
     }
 
     public boolean supportsIngress() {

--- a/skaha/src/main/java/org/opencadc/skaha/session/SessionURLBuilder.java
+++ b/skaha/src/main/java/org/opencadc/skaha/session/SessionURLBuilder.java
@@ -179,8 +179,6 @@ public abstract class SessionURLBuilder {
 
     /** Construct a URL for a Carta session. Used to redirect the end user to the Carta viewer. */
     static final class CartaSessionURLBuilder extends SessionURLBuilder {
-        private boolean useAlternateSocketURL = false;
-        private boolean useVersion5Path = false;
 
         /**
          * Constructor.
@@ -193,63 +191,21 @@ public abstract class SessionURLBuilder {
         }
 
         /**
-         * Set the use of an alternate socket for the Carta session. This only
-         *
-         * @param useAlternateSocketURL Specify the alternate socket URL, omit it otherwise.
-         * @return This builder.
-         */
-        CartaSessionURLBuilder withAlternateSocket(boolean useAlternateSocketURL) {
-            this.useAlternateSocketURL = useAlternateSocketURL;
-            return this;
-        }
-
-        /**
-         * With CARTA 5, the path to the session has changed. This method allows that to be passed through properly.
-         *
-         * @param useVersion5Path Specify whether to use the CARTA 5 path format.
-         * @return This builder.
-         */
-        CartaSessionURLBuilder withVersion5Path(boolean useVersion5Path) {
-            this.useVersion5Path = useVersion5Path;
-            return this;
-        }
-
-        /**
          * Build the URL for a Carta session. Example output: <code>
          *     <a href="https://host.example.org/session/carta/8675309">...</a>?
-         * </code> or <code>
-         *     https://host.example.org/session/carta/8675309?socketUrl=wss://host.example.org/session/carta/ws/8675309/
          * </code>
          *
          * @return URL string in format <code>
-         *     https://${host}/session/carta/${sessionID}?token=${sessionID}
+         *     https://${host}/session/carta/${sessionID}
          * </code>
          * @throws URISyntaxException If the URI cannot be created.
          */
         @Override
         String build() throws URISyntaxException {
-            final String[] pathSegments;
-
-            if (this.useVersion5Path) {
-                // CARTA 5 path format
-                pathSegments = new String[] {"session", "carta", this.sessionID, ""};
-            } else {
-                // CARTA <5 path format
-                pathSegments = new String[] {"session", "carta", "http", this.sessionID, ""};
-            }
-
+            final String[] pathSegments = new String[] {"session", "carta", this.sessionID, ""};
             final URIBuilder builder =
                     new URIBuilder().setScheme("https").setHost(this.host).setPathSegments(pathSegments);
-            final URIBuilder uriBuilder;
-
-            if (this.useAlternateSocketURL) {
-                uriBuilder = builder.setCustomQuery(
-                        String.format("socketUrl=wss://%s/session/carta/ws/%s/", this.host, this.sessionID));
-            } else {
-                uriBuilder = builder;
-            }
-
-            return uriBuilder.build().toString();
+            return builder.build().toString();
         }
     }
 

--- a/skaha/src/main/java/org/opencadc/skaha/session/UserStorageClient.java
+++ b/skaha/src/main/java/org/opencadc/skaha/session/UserStorageClient.java
@@ -10,7 +10,6 @@ import ca.nrc.cadc.net.ResourceAlreadyExistsException;
 import ca.nrc.cadc.net.ResourceNotFoundException;
 import ca.nrc.cadc.reg.Standards;
 import ca.nrc.cadc.reg.client.RegistryClient;
-import com.amazonaws.util.IOUtils;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -25,6 +24,7 @@ import java.util.concurrent.CompletionException;
 import javax.security.auth.Subject;
 import org.apache.commons.compress.archivers.tar.TarArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.io.IOUtils;
 import org.apache.log4j.Logger;
 import org.opencadc.skaha.K8SUtil;
 import org.opencadc.skaha.session.userStorage.UserStorageAdminConfiguration;
@@ -41,6 +41,10 @@ import org.opencadc.vospace.transfer.Direction;
 import org.opencadc.vospace.transfer.Protocol;
 import org.opencadc.vospace.transfer.Transfer;
 
+/**
+ * Client to manage user storage in a VOSpace service. This will also manage setting up a new User Allocation folder to
+ * ensure, for example, Desktop Sessions have what is expected in place in their home directory.
+ */
 public class UserStorageClient {
     private static final Logger LOGGER = Logger.getLogger(UserStorageClient.class);
     private static final double ONE_WEEK_DAYS = 7.0D;

--- a/skaha/src/test/java/org/opencadc/skaha/session/FlexResourceRequestConfigurationTest.java
+++ b/skaha/src/test/java/org/opencadc/skaha/session/FlexResourceRequestConfigurationTest.java
@@ -1,0 +1,68 @@
+package org.opencadc.skaha.session;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FlexResourceRequestConfigurationTest {
+
+    @Test
+    public void testBadInput() {
+        try {
+            FlexResourceRequestConfiguration.fromSessionType(null);
+            org.junit.Assert.fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException illegalArgumentException) {
+            // Good.
+        }
+
+        try {
+            FlexResourceRequestConfiguration.fromSessionType("");
+            org.junit.Assert.fail("Expected IllegalArgumentException");
+        } catch (IllegalArgumentException illegalArgumentException) {
+            // Good.
+        }
+
+        try {
+            FlexResourceRequestConfiguration.fromSessionType("notebook", null);
+            org.junit.Assert.fail("Expected NullPointerException");
+        } catch (NullPointerException nullPointerException) {
+            // Good.
+        }
+    }
+
+    @Test
+    public void testGetCPU() {
+        final Map<String, String> testEnvironment = new HashMap<>();
+        testEnvironment.put("SKAHA_FLEX_RESOURCE_REQUEST_NOTEBOOK_MEMORY", "2.0");
+        testEnvironment.put("SKAHA_FLEX_RESOURCE_REQUEST_NOTEBOOK_CPU", "1.5");
+
+        Assert.assertEquals(
+                "Values should be default.",
+                5.6D,
+                FlexResourceRequestConfiguration.fromSessionType("headless", testEnvironment)
+                        .getCPU(5.6D),
+                0.0D);
+
+        Assert.assertEquals(
+                "Values should be default.",
+                1.1D,
+                FlexResourceRequestConfiguration.fromSessionType("default", testEnvironment)
+                        .getCPU(1.1D),
+                0.0D);
+
+        Assert.assertEquals(
+                "Wrong configured CPU value.",
+                1.5D,
+                FlexResourceRequestConfiguration.fromSessionType("notebook", testEnvironment)
+                        .getCPU(13.0D),
+                0.0D);
+
+        Assert.assertEquals(
+                "Wrong configured memory value.",
+                2.0D,
+                FlexResourceRequestConfiguration.fromSessionType("notebook", testEnvironment)
+                        .getMemory(13.0D),
+                0.0D);
+    }
+}

--- a/skaha/src/test/java/org/opencadc/skaha/session/FlexResourceRequestConfigurationTest.java
+++ b/skaha/src/test/java/org/opencadc/skaha/session/FlexResourceRequestConfigurationTest.java
@@ -34,7 +34,6 @@ public class FlexResourceRequestConfigurationTest {
     @Test
     public void testGetCPU() {
         final Map<String, String> testEnvironment = new HashMap<>();
-        testEnvironment.put("SKAHA_FLEX_RESOURCE_REQUEST_NOTEBOOK_MEMORY", "2.0");
         testEnvironment.put("SKAHA_FLEX_RESOURCE_REQUEST_NOTEBOOK_CPU", "1.5");
 
         Assert.assertEquals(
@@ -57,12 +56,25 @@ public class FlexResourceRequestConfigurationTest {
                 FlexResourceRequestConfiguration.fromSessionType("notebook", testEnvironment)
                         .getCPU(13.0D),
                 0.0D);
+    }
+
+    @Test
+    public void testGetMemory() {
+        final Map<String, String> testEnvironment = new HashMap<>();
+        testEnvironment.put("SKAHA_FLEX_RESOURCE_REQUEST_HEADLESS_MEMORY", "8.0");
 
         Assert.assertEquals(
                 "Wrong configured memory value.",
-                2.0D,
+                8.0D,
+                FlexResourceRequestConfiguration.fromSessionType("headless", testEnvironment)
+                        .getMemory(16.0D),
+                0.0D);
+
+        Assert.assertEquals(
+                "Values should be default.",
+                12.0D,
                 FlexResourceRequestConfiguration.fromSessionType("notebook", testEnvironment)
-                        .getMemory(13.0D),
+                        .getCPU(12.0D),
                 0.0D);
     }
 }

--- a/skaha/src/test/java/org/opencadc/skaha/session/SessionTypeTest.java
+++ b/skaha/src/test/java/org/opencadc/skaha/session/SessionTypeTest.java
@@ -10,34 +10,19 @@ public class SessionTypeTest {
         final String currentWorkingDirectory = System.getProperty("user.home");
         final SessionType testSubject = SessionType.fromApplicationStringType("carta");
         Assert.assertEquals(
-                "Wrong legacy ingress path",
-                Path.of(currentWorkingDirectory + "/config/ingress-carta-legacy.yaml"),
-                testSubject.getIngressConfigPath(true));
-
-        Assert.assertEquals(
-                "Wrong legacy service path",
-                Path.of(currentWorkingDirectory + "/config/service-carta-legacy.yaml"),
-                testSubject.getServiceConfigPath(true));
-
-        Assert.assertEquals(
-                "Wrong legacy job config path",
-                Path.of(currentWorkingDirectory + "/config/launch-carta-legacy.yaml"),
-                testSubject.getJobConfigPath(true));
-
-        Assert.assertEquals(
                 "Wrong ingress path",
                 Path.of(currentWorkingDirectory + "/config/ingress-carta.yaml"),
-                testSubject.getIngressConfigPath(false));
+                testSubject.getIngressConfigPath());
 
         Assert.assertEquals(
                 "Wrong service path",
                 Path.of(currentWorkingDirectory + "/config/service-carta.yaml"),
-                testSubject.getServiceConfigPath(false));
+                testSubject.getServiceConfigPath());
 
         Assert.assertEquals(
                 "Wrong job config path",
                 Path.of(currentWorkingDirectory + "/config/launch-carta.yaml"),
-                testSubject.getJobConfigPath(false));
+                testSubject.getJobConfigPath());
     }
 
     @Test
@@ -47,31 +32,31 @@ public class SessionTypeTest {
         Assert.assertEquals(
                 "Wrong legacy ingress path",
                 Path.of(currentWorkingDirectory + "/config/ingress-notebook.yaml"),
-                testSubject.getIngressConfigPath(true));
+                testSubject.getIngressConfigPath());
 
         Assert.assertEquals(
                 "Wrong legacy service path",
                 Path.of(currentWorkingDirectory + "/config/service-notebook.yaml"),
-                testSubject.getServiceConfigPath(true));
+                testSubject.getServiceConfigPath());
 
         Assert.assertEquals(
                 "Wrong legacy job config path",
                 Path.of(currentWorkingDirectory + "/config/launch-notebook.yaml"),
-                testSubject.getJobConfigPath(true));
+                testSubject.getJobConfigPath());
 
         Assert.assertEquals(
                 "Wrong ingress path",
                 Path.of(currentWorkingDirectory + "/config/ingress-notebook.yaml"),
-                testSubject.getIngressConfigPath(false));
+                testSubject.getIngressConfigPath());
 
         Assert.assertEquals(
                 "Wrong service path",
                 Path.of(currentWorkingDirectory + "/config/service-notebook.yaml"),
-                testSubject.getServiceConfigPath(false));
+                testSubject.getServiceConfigPath());
 
         Assert.assertEquals(
                 "Wrong job config path",
                 Path.of(currentWorkingDirectory + "/config/launch-notebook.yaml"),
-                testSubject.getJobConfigPath(false));
+                testSubject.getJobConfigPath());
     }
 }

--- a/skaha/src/test/java/org/opencadc/skaha/session/SessionURLBuilderTest.java
+++ b/skaha/src/test/java/org/opencadc/skaha/session/SessionURLBuilderTest.java
@@ -64,23 +64,8 @@ public class SessionURLBuilderTest {
     public void testCartaSession() throws Exception {
         Assert.assertEquals(
                 "Wrong Carta URL",
-                "https://host.example.org/session/carta/http/8675309/",
+                "https://host.example.org/session/carta/8675309/",
                 SessionURLBuilder.cartaSession("host.example.org", "8675309").build());
-
-        Assert.assertEquals(
-                "Wrong Carta URL",
-                "https://host.example.org/session/carta/http/8675309/?socketUrl=wss://host.example.org/session/carta/ws/8675309/",
-                SessionURLBuilder.cartaSession("host.example.org", "8675309")
-                        .withAlternateSocket(true)
-                        .build());
-
-        final SessionURLBuilder.CartaSessionURLBuilder testSubjectWithCARTA5Path = SessionURLBuilder.cartaSession(
-                        "cartahost.example.org", "8675309")
-                .withVersion5Path(true);
-        Assert.assertEquals(
-                "Wrong Carta 5 URL",
-                "https://cartahost.example.org/session/carta/8675309/",
-                testSubjectWithCARTA5Path.build());
 
         try {
             SessionURLBuilder.cartaSession(null, "8675309").build();

--- a/skaha/src/test/resources/context-schema.json
+++ b/skaha/src/test/resources/context-schema.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$schema": "http://json-schema.org/draft-07/schema",
   "title": "ResourceConfiguration",
   "type": "object",
   "properties": {


### PR DESCRIPTION
# Description
Feature to configure default resource requests for Flexible Sessions.

# Changes
- New `FlexResourceRequestConfiguration` object to configure default request values
  - New environment variables per session type
    - `SKAHA_FLEX_RESOURCE_REQUEST_${session_type}_MEMORY`
    - `SKAHA_FLEX_RESOURCE_REQUEST_${session_type}_CPU`
  - Supports floating point or integers, **not** Kubernetes units
- Cleanup
  - Remove old CARTA support for cleanup
  - Replace JSON Schema library to remove CVE


CADC-14988