### PR TITLE
fix: fix for how session denied access is conveyed

### DIFF
--- a/helm/Chart.yaml
+++ b/helm/Chart.yaml
@@ -21,13 +21,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 1.6.0
+version: 1.6.1-rc.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.3.0"
+appVersion: "1.3.1"
 
 dependencies:
   - name: "redis"

--- a/helm/templates/skaha-tomcat-deployment.yaml
+++ b/helm/templates/skaha-tomcat-deployment.yaml
@@ -5,6 +5,10 @@ metadata:
     run: {{ .Release.Name }}-skaha-tomcat
   name: {{ .Release.Name }}-skaha-tomcat
   namespace: {{ .Release.Namespace }}
+  {{- with .Values.deployment.skaha.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   {{- if not (default false .Values.autoscaling.enabled) }}
   replicas: {{ default 1 .Values.replicaCount }}
@@ -17,6 +21,10 @@ spec:
       creationTimestamp: null
       labels:
         run: {{ .Release.Name }}-skaha-tomcat
+      {{- with .Values.deployment.skaha.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
     spec:
       {{- with .Values.deployment.skaha.imagePullSecrets }}
       imagePullSecrets:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -51,6 +51,11 @@ deployment:
     # -- Image pull policy for the Skaha API container.
     imagePullPolicy: Always
 
+    # -- Annotations added to the Skaha API Deployment metadata.
+    annotations: {}
+    # -- Annotations added to the Skaha API Pod template metadata.
+    podAnnotations: {}
+
     # Cron string for the image caching cron job schedule. Defaults to every half hour.
     imageCache:
       # -- Cron schedule used to refresh cached images.

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -47,7 +47,7 @@ deployment:
   hostname: myhost.example.com  # Change this!
   skaha:
     # -- Container image for the Skaha API service.
-    image: images.opencadc.org/platform/skaha:1.3.0
+    image: images.opencadc.org/platform/skaha:1.3.1
     # -- Image pull policy for the Skaha API container.
     imagePullPolicy: Always
 

--- a/skaha/src/main/java/org/opencadc/skaha/SkahaAction.java
+++ b/skaha/src/main/java/org/opencadc/skaha/SkahaAction.java
@@ -172,10 +172,19 @@ public abstract class SkahaAction extends RestAction {
     }
 
     /**
-     * Override here to handle the generic SecurityException for users not authenticated.
+     * Maps {@link SessionAccessDeniedException} to HTTP 403 Forbidden.
      *
-     * @return Object resulting from a run. Possibly null.
-     * @throws Exception For any exceptions, caught or otherwise.
+     * <p>{@link ca.nrc.cadc.rest.RestAction#run()} handles {@link java.security.AccessControlException} as 403, but not
+     * {@code SessionAccessDeniedException}. Skaha uses the latter (see
+     * {@link org.opencadc.skaha.session.authorization.SessionAccessDeniedException}) because
+     * {@code AccessControlException} is deprecated. Without this override, an authorization failure would escape
+     * {@code RestAction} and be reported as a server error (500).
+     *
+     * <p>Missing or invalid authentication is still handled by {@code RestAction} via
+     * {@link ca.nrc.cadc.auth.NotAuthenticatedException} (401).
+     *
+     * @return the result of {@code super.run()}, or {@code null} after a handled 403 response
+     * @throws Exception if {@code super.run()} throws any exception other than {@code SessionAccessDeniedException}
      */
     @Override
     public Object run() throws Exception {

--- a/skaha/src/main/java/org/opencadc/skaha/SkahaAction.java
+++ b/skaha/src/main/java/org/opencadc/skaha/SkahaAction.java
@@ -171,6 +171,25 @@ public abstract class SkahaAction extends RestAction {
         }
     }
 
+    /**
+     * Override here to handle the generic SecurityException for users not authenticated.
+     *
+     * @return Object resulting from a run. Possibly null.
+     * @throws Exception For any exceptions, caught or otherwise.
+     */
+    @Override
+    public Object run() throws Exception {
+        try {
+            return super.run();
+        } catch (SessionAccessDeniedException sessionAccessDeniedException) {
+            logInfo.setSuccess(true);
+            logInfo.setMessage(sessionAccessDeniedException.getMessage());
+            handleException(sessionAccessDeniedException, 403, sessionAccessDeniedException.getMessage(), false, false);
+        }
+
+        return null;
+    }
+
     protected static SkahaCallbackTokenTool getSkahaCallbackTokenTool() throws Exception {
         final EncodedKeyPair encodedKeyPair = getPreAuthorizedTokenSecret();
         return new SkahaCallbackTokenTool(encodedKeyPair.encodedPublicKey, encodedKeyPair.encodedPrivateKey);


### PR DESCRIPTION
Temporary fix until SecurityException is handled in the main runner class (`core/cadc-util`).

Also includes support for annotations in the `skaha` Helm Chart.