### PR TITLE
feat(skaha): OTel Java Agent

### DIFF
--- a/.github/workflows/ci.testing.yml
+++ b/.github/workflows/ci.testing.yml
@@ -39,6 +39,12 @@ jobs:
         run: |
             cd skaha
             ./gradlew clean check --no-daemon
+      - name: Setup Helm
+        uses: azure/setup-helm@v5
+        with:
+          version: v3.21.0
+      - name: Run Helm Render Tests
+        run: helm/tests/test-skaha-otel-render.sh
       - name: Upload coverage artifacts
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a
         with:

--- a/helm/README.md
+++ b/helm/README.md
@@ -2,9 +2,9 @@
 
 A Helm chart to install the Skaha web service of the CANFAR Science Platform
 
-|                 Chart                 | AppVersion | Type |
-|:-------------------------------------:|:----------:|:----:|
-|1.6.0<!-- x-release-please-version --> | 1.3.0 | application |
+| Chart | AppVersion | Type |
+|:-----:|:----------:|:----:|
+|1.6.1-rc.1<!-- x-release-please-version --> | 1.3.1 | application |
 
 ## Requirements
 
@@ -20,16 +20,18 @@ A Helm chart to install the Skaha web service of the CANFAR Science Platform
 | autoscaling.maxReplicas | int | `6` | Maximum number of skaha-tomcat replicas. |
 | autoscaling.minReplicas | int | `2` | Minimum number of skaha-tomcat replicas. |
 | deployment.hostname | string | `"myhost.example.com"` | Public hostname for the Skaha API. |
+| deployment.skaha.annotations | object | `{}` | Annotations added to the Skaha API Deployment metadata. |
 | deployment.skaha.apiVersion | string | `"v1"` | Skaha API version path segment (for example, `v1` -> `/skaha/v1/...`). |
 | deployment.skaha.cookieSignaturePublicKey.existingSecret.name | string | `""` |  |
 | deployment.skaha.cookieSignaturePublicKey.existingSecret.path | string | `""` |  |
 | deployment.skaha.defaultQuotaGB | string | `"10"` | Default user storage quota in GiB for first-time users. |
 | deployment.skaha.identityManagerClass | string | `"org.opencadc.auth.StandardIdentityManager"` | Java IdentityManager implementation used for authentication. |
-| deployment.skaha.image | string | `"images.opencadc.org/platform/skaha:1.3.0"` | Container image for the Skaha API service. |
+| deployment.skaha.image | string | `"images.opencadc.org/platform/skaha:1.3.1"` | Container image for the Skaha API service. |
 | deployment.skaha.imageCache.refreshSchedule | string | `"*/30 * * * *"` | Cron schedule used to refresh cached images. |
 | deployment.skaha.imagePullPolicy | string | `"Always"` | Image pull policy for the Skaha API container. |
 | deployment.skaha.init.image | string | `"busybox:1.37.0"` | Init container image used to bootstrap user storage paths. |
 | deployment.skaha.init.imagePullPolicy | string | `"IfNotPresent"` | Image pull policy for the bootstrap init container. |
+| deployment.skaha.podAnnotations | object | `{}` | Annotations added to the Skaha API Pod template metadata. |
 | deployment.skaha.posixMapperCacheTTLSeconds | string | `"86400"` | TTL in seconds for cached POSIX mapper entries. |
 | deployment.skaha.registryHosts | string | `"images.canfar.net"` | Space-delimited list of image registry hosts allowed for sessions. |
 | deployment.skaha.resources.limits.cpu | string | `"2000m"` | CPU limit for the Skaha API container. |
@@ -105,6 +107,10 @@ A Helm chart to install the Skaha web service of the CANFAR Science Platform
 | securityContext | object | `{}` | Optional Pod-level security context for the Skaha API Deployment. |
 | service.port | int | `8080` | Service port exposed for the Skaha API Service. |
 | serviceAccount | object | `{"annotations":{},"automount":true,"create":true,"name":""}` | ServiceAccount used by the Skaha API Pod. |
+| telemetry.exportIntervalSeconds | int | `60` | Export interval in seconds for Skaha Java-agent metrics. |
+| telemetry.metrics.skahaServiceName | string | `"canfar-skaha"` | OpenTelemetry service.name for the Skaha Tomcat workload. |
+| telemetry.otlpEndpoint | string | `""` | OTLP HTTP collector endpoint shared by Science Platform telemetry exporters. Required when telemetry.skahaEnabled is true. |
+| telemetry.skahaEnabled | bool | `false` | Enable the OpenTelemetry Java agent on the Skaha Tomcat container. Requires telemetry.otlpEndpoint. |
 | tolerations | list | `[]` | Tolerations applied to the Skaha API Pod. |
 
 ## User storage (Cavern)
@@ -164,6 +170,21 @@ deployment:
 ```
 
 API specification: https://permissions.srcnet.skao.int/api/openapi.json
+
+## Skaha OpenTelemetry
+
+Skaha OpenTelemetry is off by default. To enable v1 metrics export for the Tomcat workload, set both `telemetry.skahaEnabled: true` and `telemetry.otlpEndpoint` to the ops-provided OTLP HTTP collector endpoint.
+
+When enabled, the chart attaches the image-bundled OpenTelemetry Java agent with `CATALINA_OPTS` and emits standard `OTEL_*` environment variables for metrics-only OTLP export. Traces and logs are explicitly disabled with `OTEL_TRACES_EXPORTER=none` and `OTEL_LOGS_EXPORTER=none`; v1 does not deploy a collector or add Prometheus scrape endpoints.
+
+```yaml
+telemetry:
+  skahaEnabled: true
+  otlpEndpoint: "http://otel-collector.observability.svc.cluster.local:4318"
+  exportIntervalSeconds: 60
+  metrics:
+    skahaServiceName: canfar-skaha
+```
 
 ## Harbor publishing (Science Platform CI)
 

--- a/helm/README.md
+++ b/helm/README.md
@@ -107,10 +107,10 @@ A Helm chart to install the Skaha web service of the CANFAR Science Platform
 | securityContext | object | `{}` | Optional Pod-level security context for the Skaha API Deployment. |
 | service.port | int | `8080` | Service port exposed for the Skaha API Service. |
 | serviceAccount | object | `{"annotations":{},"automount":true,"create":true,"name":""}` | ServiceAccount used by the Skaha API Pod. |
-| telemetry.exportIntervalSeconds | int | `60` | Export interval in seconds for Skaha Java-agent metrics. |
-| telemetry.metrics.skahaServiceName | string | `"canfar-skaha"` | OpenTelemetry service.name for the Skaha Tomcat workload. |
-| telemetry.otlpEndpoint | string | `""` | OTLP HTTP collector endpoint shared by Science Platform telemetry exporters. Required when telemetry.skahaEnabled is true. |
-| telemetry.skahaEnabled | bool | `false` | Enable the OpenTelemetry Java agent on the Skaha Tomcat container. Requires telemetry.otlpEndpoint. |
+| telemetry.controller | bool | `false` | Enable OpenTelemetry metrics for the Skaha controller Tomcat workload (`OTEL_SERVICE_NAME=skaha-controller`). Requires telemetry.otlp.destination. |
+| telemetry.metrics | bool | `false` | Reserved for future OpenTelemetry metrics emitted by the Python metrics backend (`OTEL_SERVICE_NAME=skaha-metrics`). Must remain false in this chart version. |
+| telemetry.otlp.destination | string | `""` | OTLP HTTP collector endpoint where enabled telemetry services POST metrics. |
+| telemetry.otlp.interval | int | `30` | Export interval in seconds for enabled telemetry services. |
 | tolerations | list | `[]` | Tolerations applied to the Skaha API Pod. |
 
 ## User storage (Cavern)
@@ -173,17 +173,17 @@ API specification: https://permissions.srcnet.skao.int/api/openapi.json
 
 ## Skaha OpenTelemetry
 
-Skaha OpenTelemetry is off by default. To enable v1 metrics export for the Tomcat workload, set both `telemetry.skahaEnabled: true` and `telemetry.otlpEndpoint` to the ops-provided OTLP HTTP collector endpoint.
+Skaha OpenTelemetry is off by default. To enable v1 metrics export for the Tomcat controller workload, set `telemetry.controller: true` and `telemetry.otlp.destination` to the ops-provided OTLP HTTP collector endpoint.
 
-When enabled, the chart attaches the image-bundled OpenTelemetry Java agent with `CATALINA_OPTS` and emits standard `OTEL_*` environment variables for metrics-only OTLP export. Traces and logs are explicitly disabled with `OTEL_TRACES_EXPORTER=none` and `OTEL_LOGS_EXPORTER=none`; v1 does not deploy a collector or add Prometheus scrape endpoints.
+When enabled, the chart attaches the image-bundled OpenTelemetry Java agent with `CATALINA_OPTS` and emits standard `OTEL_*` environment variables for metrics-only OTLP export. Skaha controller metrics always use `OTEL_SERVICE_NAME=skaha-controller`; `telemetry.metrics` is reserved for the future Python metrics backend name `skaha-metrics` and must remain false in this chart version. Traces and logs are explicitly disabled with `OTEL_TRACES_EXPORTER=none` and `OTEL_LOGS_EXPORTER=none`; v1 does not deploy a collector or add Prometheus scrape endpoints.
 
 ```yaml
 telemetry:
-  skahaEnabled: true
-  otlpEndpoint: "http://otel-collector.observability.svc.cluster.local:4318"
-  exportIntervalSeconds: 60
-  metrics:
-    skahaServiceName: canfar-skaha
+  controller: true
+  metrics: false
+  otlp:
+    destination: "http://otel-collector.observability.svc.cluster.local:4318"
+    interval: 30
 ```
 
 ## Harbor publishing (Science Platform CI)

--- a/helm/README.md.gotmpl
+++ b/helm/README.md.gotmpl
@@ -70,6 +70,21 @@ deployment:
 
 API specification: https://permissions.srcnet.skao.int/api/openapi.json
 
+## Skaha OpenTelemetry
+
+Skaha OpenTelemetry is off by default. To enable v1 metrics export for the Tomcat workload, set both `telemetry.skahaEnabled: true` and `telemetry.otlpEndpoint` to the ops-provided OTLP HTTP collector endpoint.
+
+When enabled, the chart attaches the image-bundled OpenTelemetry Java agent with `CATALINA_OPTS` and emits standard `OTEL_*` environment variables for metrics-only OTLP export. Traces and logs are explicitly disabled with `OTEL_TRACES_EXPORTER=none` and `OTEL_LOGS_EXPORTER=none`; v1 does not deploy a collector or add Prometheus scrape endpoints.
+
+```yaml
+telemetry:
+  skahaEnabled: true
+  otlpEndpoint: "http://otel-collector.observability.svc.cluster.local:4318"
+  exportIntervalSeconds: 60
+  metrics:
+    skahaServiceName: canfar-skaha
+```
+
 ## Harbor publishing (Science Platform CI)
 
 Successful Skaha image releases (`CD: Skaha Release Build`) also package this chart (`helm dependency build`, `helm package`) and upload the `.tgz` to Harbor via the **classic Helm chartrepo API**:

--- a/helm/README.md.gotmpl
+++ b/helm/README.md.gotmpl
@@ -72,17 +72,17 @@ API specification: https://permissions.srcnet.skao.int/api/openapi.json
 
 ## Skaha OpenTelemetry
 
-Skaha OpenTelemetry is off by default. To enable v1 metrics export for the Tomcat workload, set both `telemetry.skahaEnabled: true` and `telemetry.otlpEndpoint` to the ops-provided OTLP HTTP collector endpoint.
+Skaha OpenTelemetry is off by default. To enable v1 metrics export for the Tomcat controller workload, set `telemetry.controller: true` and `telemetry.otlp.destination` to the ops-provided OTLP HTTP collector endpoint.
 
-When enabled, the chart attaches the image-bundled OpenTelemetry Java agent with `CATALINA_OPTS` and emits standard `OTEL_*` environment variables for metrics-only OTLP export. Traces and logs are explicitly disabled with `OTEL_TRACES_EXPORTER=none` and `OTEL_LOGS_EXPORTER=none`; v1 does not deploy a collector or add Prometheus scrape endpoints.
+When enabled, the chart attaches the image-bundled OpenTelemetry Java agent with `CATALINA_OPTS` and emits standard `OTEL_*` environment variables for metrics-only OTLP export. Skaha controller metrics always use `OTEL_SERVICE_NAME=skaha-controller`; `telemetry.metrics` is reserved for the future Python metrics backend name `skaha-metrics` and must remain false in this chart version. Traces and logs are explicitly disabled with `OTEL_TRACES_EXPORTER=none` and `OTEL_LOGS_EXPORTER=none`; v1 does not deploy a collector or add Prometheus scrape endpoints.
 
 ```yaml
 telemetry:
-  skahaEnabled: true
-  otlpEndpoint: "http://otel-collector.observability.svc.cluster.local:4318"
-  exportIntervalSeconds: 60
-  metrics:
-    skahaServiceName: canfar-skaha
+  controller: true
+  metrics: false
+  otlp:
+    destination: "http://otel-collector.observability.svc.cluster.local:4318"
+    interval: 30
 ```
 
 ## Harbor publishing (Science Platform CI)

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -226,14 +226,23 @@ OpenTelemetry validation for the Skaha Java agent.
 */}}
 {{- define "skaha.validateTelemetry" }}
 {{- $telemetry := .Values.telemetry | default dict -}}
-{{- $endpoint := trim (default "" $telemetry.otlpEndpoint | toString) -}}
-{{- if and (default false $telemetry.skahaEnabled) (not $endpoint) }}
-{{- fail "telemetry.skahaEnabled is true but telemetry.otlpEndpoint is empty." }}
+{{- $otlp := $telemetry.otlp | default dict -}}
+{{- $endpoint := trim (default "" $otlp.destination | toString) -}}
+{{- $controllerEnabled := default false $telemetry.controller -}}
+{{- $interval := trim ((default 30 $otlp.interval) | toString) -}}
+{{- if default false $telemetry.metrics }}
+{{- fail "telemetry.metrics is reserved for future skaha-metrics OpenTelemetry support and must remain false in this chart version." }}
 {{- end }}
-{{- if and (default false $telemetry.skahaEnabled) $endpoint }}
+{{- if and $controllerEnabled (not $endpoint) }}
+{{- fail "telemetry.controller is true but telemetry.otlp.destination is empty." }}
+{{- end }}
+{{- if and $controllerEnabled (not (regexMatch "^[1-9][0-9]*$" $interval)) }}
+{{- fail "telemetry.otlp.interval must be a positive integer number of seconds when telemetry.controller is true." }}
+{{- end }}
+{{- if and $controllerEnabled $endpoint }}
 {{- range $index, $env := (.Values.deployment.skaha.extraEnv | default list) }}
 {{- if eq (default "" $env.name | toString) "CATALINA_OPTS" }}
-{{- fail "deployment.skaha.extraEnv cannot set CATALINA_OPTS when telemetry.skahaEnabled is true; telemetry manages the OpenTelemetry Java agent CATALINA_OPTS." }}
+{{- fail "deployment.skaha.extraEnv cannot set CATALINA_OPTS when telemetry.controller is true; telemetry manages the OpenTelemetry Java agent CATALINA_OPTS." }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/helm/templates/_helpers.tpl
+++ b/helm/templates/_helpers.tpl
@@ -222,6 +222,24 @@ Structural validation only; Skaha rejects conflicting modes at runtime.
 {{- end }}
 
 {{/*
+OpenTelemetry validation for the Skaha Java agent.
+*/}}
+{{- define "skaha.validateTelemetry" }}
+{{- $telemetry := .Values.telemetry | default dict -}}
+{{- $endpoint := trim (default "" $telemetry.otlpEndpoint | toString) -}}
+{{- if and (default false $telemetry.skahaEnabled) (not $endpoint) }}
+{{- fail "telemetry.skahaEnabled is true but telemetry.otlpEndpoint is empty." }}
+{{- end }}
+{{- if and (default false $telemetry.skahaEnabled) $endpoint }}
+{{- range $index, $env := (.Values.deployment.skaha.extraEnv | default list) }}
+{{- if eq (default "" $env.name | toString) "CATALINA_OPTS" }}
+{{- fail "deployment.skaha.extraEnv cannot set CATALINA_OPTS when telemetry.skahaEnabled is true; telemetry manages the OpenTelemetry Java agent CATALINA_OPTS." }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
 USER SESSION TEMPLATE DEFINITIONS
 */}}
 

--- a/helm/templates/skaha-tomcat-deployment.yaml
+++ b/helm/templates/skaha-tomcat-deployment.yaml
@@ -47,10 +47,8 @@ spec:
       {{- $cspkRoot := (.Values.deployment.skaha.cookieSignaturePublicKey | default dict) }}
       {{- $cspkRef := ($cspkRoot.existingSecret | default dict) }}
       {{- $telemetry := .Values.telemetry | default dict }}
-      {{- $telemetryMetrics := $telemetry.metrics | default dict }}
-      {{- $telemetryEndpoint := trim (default "" $telemetry.otlpEndpoint | toString) }}
-      {{- $skahaTelemetryEnabled := and (default false $telemetry.skahaEnabled) $telemetryEndpoint }}
-      {{- $telemetryExportIntervalMillis := mul (int ($telemetry.exportIntervalSeconds | default 60)) 1000 }}
+      {{- $telemetryOtlp := $telemetry.otlp | default dict }}
+      {{- $telemetryEndpoint := trim (default "" $telemetryOtlp.destination | toString) }}
       {{- $cookiePubSecretName := trim (($cspkRef.name | default "") | toString) }}
       {{- $cookiePubMountPath := "" }}
       {{- if trim (($cspkRef.path | default "") | toString) }}
@@ -176,11 +174,11 @@ spec:
         {{- end }}
         - name: SKAHA_EXPERIMENTAL_FEATURE_GATES
           value: "{{ include "skaha.experimentalFeatureGates" $ }}"
-        {{- if $skahaTelemetryEnabled }}
+        {{- if and (default false $telemetry.controller) $telemetryEndpoint }}
         - name: CATALINA_OPTS
           value: "-javaagent:/opt/opentelemetry-javaagent/opentelemetry-javaagent.jar"
         - name: OTEL_SERVICE_NAME
-          value: {{ ($telemetryMetrics.skahaServiceName | default "canfar-skaha") | quote }}
+          value: "skaha-controller"
         - name: OTEL_METRICS_EXPORTER
           value: "otlp"
         - name: OTEL_EXPORTER_OTLP_ENDPOINT
@@ -188,7 +186,7 @@ spec:
         - name: OTEL_EXPORTER_OTLP_PROTOCOL
           value: "http/protobuf"
         - name: OTEL_METRIC_EXPORT_INTERVAL
-          value: {{ $telemetryExportIntervalMillis | quote }}
+          value: {{ mul (int ($telemetryOtlp.interval | default 30)) 1000 | quote }}
         - name: OTEL_TRACES_EXPORTER
           value: "none"
         - name: OTEL_LOGS_EXPORTER

--- a/helm/templates/skaha-tomcat-deployment.yaml
+++ b/helm/templates/skaha-tomcat-deployment.yaml
@@ -42,9 +42,15 @@ spec:
       containers:
       - env:
       {{- include "skaha.validatePlatformAccess" . }}
+      {{- include "skaha.validateTelemetry" . }}
       {{ $userStorage := required "Missing .Values.deployment.skaha.sessions.userStorage configuration" .Values.deployment.skaha.sessions.userStorage }}
       {{- $cspkRoot := (.Values.deployment.skaha.cookieSignaturePublicKey | default dict) }}
       {{- $cspkRef := ($cspkRoot.existingSecret | default dict) }}
+      {{- $telemetry := .Values.telemetry | default dict }}
+      {{- $telemetryMetrics := $telemetry.metrics | default dict }}
+      {{- $telemetryEndpoint := trim (default "" $telemetry.otlpEndpoint | toString) }}
+      {{- $skahaTelemetryEnabled := and (default false $telemetry.skahaEnabled) $telemetryEndpoint }}
+      {{- $telemetryExportIntervalMillis := mul (int ($telemetry.exportIntervalSeconds | default 60)) 1000 }}
       {{- $cookiePubSecretName := trim (($cspkRef.name | default "") | toString) }}
       {{- $cookiePubMountPath := "" }}
       {{- if trim (($cspkRef.path | default "") | toString) }}
@@ -170,6 +176,24 @@ spec:
         {{- end }}
         - name: SKAHA_EXPERIMENTAL_FEATURE_GATES
           value: "{{ include "skaha.experimentalFeatureGates" $ }}"
+        {{- if $skahaTelemetryEnabled }}
+        - name: CATALINA_OPTS
+          value: "-javaagent:/opt/opentelemetry-javaagent/opentelemetry-javaagent.jar"
+        - name: OTEL_SERVICE_NAME
+          value: {{ ($telemetryMetrics.skahaServiceName | default "canfar-skaha") | quote }}
+        - name: OTEL_METRICS_EXPORTER
+          value: "otlp"
+        - name: OTEL_EXPORTER_OTLP_ENDPOINT
+          value: {{ $telemetryEndpoint | quote }}
+        - name: OTEL_EXPORTER_OTLP_PROTOCOL
+          value: "http/protobuf"
+        - name: OTEL_METRIC_EXPORT_INTERVAL
+          value: {{ $telemetryExportIntervalMillis | quote }}
+        - name: OTEL_TRACES_EXPORTER
+          value: "none"
+        - name: OTEL_LOGS_EXPORTER
+          value: "none"
+        {{- end }}
         {{- with .Values.deployment.skaha.extraEnv }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/helm/tests/test-skaha-otel-render.sh
+++ b/helm/tests/test-skaha-otel-render.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+chart_dir="${1:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+
+helm dependency build "${chart_dir}" >/dev/null
+
+render_skaha_deployment() {
+    helm template otel-test "${chart_dir}" \
+        --show-only templates/skaha-tomcat-deployment.yaml \
+        --set deployment.skaha.sessions.userStorage.nodeURIPrefix=vos://storage.example.org~cavern \
+        "$@"
+}
+
+assert_not_contains() {
+    local content="$1"
+    local unexpected="$2"
+
+    if grep -Fq -- "${unexpected}" <<<"${content}"; then
+        printf 'Expected rendered chart not to contain:\n%s\n' "${unexpected}" >&2
+        exit 1
+    fi
+}
+
+assert_env_value() {
+    local content="$1"
+    local name="$2"
+    local expected="$3"
+    local block
+
+    block="$(grep -A1 -F -- "- name: ${name}" <<<"${content}" || true)"
+    if ! grep -Fq -- "value: \"${expected}\"" <<<"${block}"; then
+        printf 'Expected rendered env %s to have value:\n%s\n' "${name}" "${expected}" >&2
+        exit 1
+    fi
+}
+
+disabled_render="$(render_skaha_deployment)"
+assert_not_contains "${disabled_render}" "OTEL_"
+assert_not_contains "${disabled_render}" "-javaagent:/opt/opentelemetry-javaagent/opentelemetry-javaagent.jar"
+
+endpoint_only_render="$(render_skaha_deployment --set telemetry.otlpEndpoint=http://otel-collector:4318)"
+assert_not_contains "${endpoint_only_render}" "OTEL_"
+assert_not_contains "${endpoint_only_render}" "-javaagent:/opt/opentelemetry-javaagent/opentelemetry-javaagent.jar"
+
+enabled_render="$(
+    render_skaha_deployment \
+        --set telemetry.skahaEnabled=true \
+        --set telemetry.otlpEndpoint=http://otel-collector:4318 \
+        --set telemetry.exportIntervalSeconds=15
+)"
+assert_env_value "${enabled_render}" "CATALINA_OPTS" "-javaagent:/opt/opentelemetry-javaagent/opentelemetry-javaagent.jar"
+assert_env_value "${enabled_render}" "OTEL_SERVICE_NAME" "canfar-skaha"
+assert_env_value "${enabled_render}" "OTEL_METRICS_EXPORTER" "otlp"
+assert_env_value "${enabled_render}" "OTEL_EXPORTER_OTLP_ENDPOINT" "http://otel-collector:4318"
+assert_env_value "${enabled_render}" "OTEL_EXPORTER_OTLP_PROTOCOL" "http/protobuf"
+assert_env_value "${enabled_render}" "OTEL_METRIC_EXPORT_INTERVAL" "15000"
+assert_env_value "${enabled_render}" "OTEL_TRACES_EXPORTER" "none"
+assert_env_value "${enabled_render}" "OTEL_LOGS_EXPORTER" "none"
+
+if missing_endpoint_err="$(render_skaha_deployment --set telemetry.skahaEnabled=true 2>&1 >/dev/null)"; then
+    printf 'Expected telemetry.skahaEnabled=true without telemetry.otlpEndpoint to fail.\n' >&2
+    exit 1
+fi
+
+if ! grep -Fq "telemetry.skahaEnabled is true but telemetry.otlpEndpoint is empty" <<<"${missing_endpoint_err}"; then
+    printf 'Expected missing endpoint error, got:\n' >&2
+    printf '%s\n' "${missing_endpoint_err}" >&2
+    exit 1
+fi
+
+if catalina_conflict_err="$(
+    render_skaha_deployment \
+        --set telemetry.skahaEnabled=true \
+        --set telemetry.otlpEndpoint=http://otel-collector:4318 \
+        --set deployment.skaha.extraEnv[0].name=CATALINA_OPTS \
+        --set deployment.skaha.extraEnv[0].value=-Xmx1g \
+        2>&1 >/dev/null
+)"; then
+    printf 'Expected telemetry-managed CATALINA_OPTS to reject deployment.skaha.extraEnv CATALINA_OPTS.\n' >&2
+    exit 1
+fi
+
+if ! grep -Fq "deployment.skaha.extraEnv cannot set CATALINA_OPTS when telemetry.skahaEnabled is true" <<<"${catalina_conflict_err}"; then
+    printf 'Expected CATALINA_OPTS conflict error, got:\n' >&2
+    printf '%s\n' "${catalina_conflict_err}" >&2
+    exit 1
+fi

--- a/helm/tests/test-skaha-otel-render.sh
+++ b/helm/tests/test-skaha-otel-render.sh
@@ -35,22 +35,49 @@ assert_env_value() {
     fi
 }
 
+assert_render_fails() {
+    local expected="$1"
+    shift
+    local error
+    local status
+
+    set +e
+    error="$(render_skaha_deployment "$@" 2>&1 >/dev/null)"
+    status=$?
+    set -e
+
+    if [[ ${status} -eq 0 ]]; then
+        printf 'Expected rendered chart to fail with:\n%s\n' "${expected}" >&2
+        exit 1
+    fi
+
+    if ! grep -Fq "${expected}" <<<"${error}"; then
+        printf 'Expected render error:\n%s\nGot:\n%s\n' "${expected}" "${error}" >&2
+        exit 1
+    fi
+}
+
 disabled_render="$(render_skaha_deployment)"
 assert_not_contains "${disabled_render}" "OTEL_"
 assert_not_contains "${disabled_render}" "-javaagent:/opt/opentelemetry-javaagent/opentelemetry-javaagent.jar"
 
-endpoint_only_render="$(render_skaha_deployment --set telemetry.otlpEndpoint=http://otel-collector:4318)"
+endpoint_only_render="$(render_skaha_deployment --set telemetry.otlp.destination=http://otel-collector:4318)"
 assert_not_contains "${endpoint_only_render}" "OTEL_"
 assert_not_contains "${endpoint_only_render}" "-javaagent:/opt/opentelemetry-javaagent/opentelemetry-javaagent.jar"
 
+assert_render_fails \
+    "telemetry.metrics is reserved for future skaha-metrics OpenTelemetry support" \
+    --set telemetry.metrics=true \
+    --set telemetry.otlp.destination=http://otel-collector:4318
+
 enabled_render="$(
     render_skaha_deployment \
-        --set telemetry.skahaEnabled=true \
-        --set telemetry.otlpEndpoint=http://otel-collector:4318 \
-        --set telemetry.exportIntervalSeconds=15
+        --set telemetry.controller=true \
+        --set telemetry.otlp.destination=http://otel-collector:4318 \
+        --set telemetry.otlp.interval=15
 )"
 assert_env_value "${enabled_render}" "CATALINA_OPTS" "-javaagent:/opt/opentelemetry-javaagent/opentelemetry-javaagent.jar"
-assert_env_value "${enabled_render}" "OTEL_SERVICE_NAME" "canfar-skaha"
+assert_env_value "${enabled_render}" "OTEL_SERVICE_NAME" "skaha-controller"
 assert_env_value "${enabled_render}" "OTEL_METRICS_EXPORTER" "otlp"
 assert_env_value "${enabled_render}" "OTEL_EXPORTER_OTLP_ENDPOINT" "http://otel-collector:4318"
 assert_env_value "${enabled_render}" "OTEL_EXPORTER_OTLP_PROTOCOL" "http/protobuf"
@@ -58,31 +85,19 @@ assert_env_value "${enabled_render}" "OTEL_METRIC_EXPORT_INTERVAL" "15000"
 assert_env_value "${enabled_render}" "OTEL_TRACES_EXPORTER" "none"
 assert_env_value "${enabled_render}" "OTEL_LOGS_EXPORTER" "none"
 
-if missing_endpoint_err="$(render_skaha_deployment --set telemetry.skahaEnabled=true 2>&1 >/dev/null)"; then
-    printf 'Expected telemetry.skahaEnabled=true without telemetry.otlpEndpoint to fail.\n' >&2
-    exit 1
-fi
+assert_render_fails \
+    "telemetry.controller is true but telemetry.otlp.destination is empty" \
+    --set telemetry.controller=true
 
-if ! grep -Fq "telemetry.skahaEnabled is true but telemetry.otlpEndpoint is empty" <<<"${missing_endpoint_err}"; then
-    printf 'Expected missing endpoint error, got:\n' >&2
-    printf '%s\n' "${missing_endpoint_err}" >&2
-    exit 1
-fi
+assert_render_fails \
+    "telemetry.otlp.interval must be a positive integer number of seconds when telemetry.controller is true" \
+    --set telemetry.controller=true \
+    --set telemetry.otlp.destination=http://otel-collector:4318 \
+    --set telemetry.otlp.interval=bogus
 
-if catalina_conflict_err="$(
-    render_skaha_deployment \
-        --set telemetry.skahaEnabled=true \
-        --set telemetry.otlpEndpoint=http://otel-collector:4318 \
-        --set deployment.skaha.extraEnv[0].name=CATALINA_OPTS \
-        --set deployment.skaha.extraEnv[0].value=-Xmx1g \
-        2>&1 >/dev/null
-)"; then
-    printf 'Expected telemetry-managed CATALINA_OPTS to reject deployment.skaha.extraEnv CATALINA_OPTS.\n' >&2
-    exit 1
-fi
-
-if ! grep -Fq "deployment.skaha.extraEnv cannot set CATALINA_OPTS when telemetry.skahaEnabled is true" <<<"${catalina_conflict_err}"; then
-    printf 'Expected CATALINA_OPTS conflict error, got:\n' >&2
-    printf '%s\n' "${catalina_conflict_err}" >&2
-    exit 1
-fi
+assert_render_fails \
+    "deployment.skaha.extraEnv cannot set CATALINA_OPTS when telemetry.controller is true" \
+    --set telemetry.controller=true \
+    --set telemetry.otlp.destination=http://otel-collector:4318 \
+    --set deployment.skaha.extraEnv[0].name=CATALINA_OPTS \
+    --set deployment.skaha.extraEnv[0].value=-Xmx1g

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -579,17 +579,17 @@ ingress:
   # -- Ingress path prefix routed to the Skaha API Service.
   path: /skaha
 
-# OpenTelemetry export is disabled unless skahaEnabled is true and otlpEndpoint is non-empty.
+# OpenTelemetry export is disabled unless the target service toggle is true and telemetry.otlp.destination is non-empty.
 telemetry:
-  # -- OTLP HTTP collector endpoint shared by Science Platform telemetry exporters. Required when telemetry.skahaEnabled is true.
-  otlpEndpoint: ""
-  # -- Export interval in seconds for Skaha Java-agent metrics.
-  exportIntervalSeconds: 60
-  # -- Enable the OpenTelemetry Java agent on the Skaha Tomcat container. Requires telemetry.otlpEndpoint.
-  skahaEnabled: false
-  metrics:
-    # -- OpenTelemetry service.name for the Skaha Tomcat workload.
-    skahaServiceName: canfar-skaha
+  # -- Enable OpenTelemetry metrics for the Skaha controller Tomcat workload (`OTEL_SERVICE_NAME=skaha-controller`). Requires telemetry.otlp.destination.
+  controller: false
+  # -- Reserved for future OpenTelemetry metrics emitted by the Python metrics backend (`OTEL_SERVICE_NAME=skaha-metrics`). Must remain false in this chart version.
+  metrics: false
+  otlp:
+    # -- OTLP HTTP collector endpoint where enabled telemetry services POST metrics.
+    destination: ""
+    # -- Export interval in seconds for enabled telemetry services.
+    interval: 30
 
 # Optional science-platform Metrics API in the same release as Skaha (see README).
 metricsBackend:

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -579,6 +579,18 @@ ingress:
   # -- Ingress path prefix routed to the Skaha API Service.
   path: /skaha
 
+# OpenTelemetry export is disabled unless skahaEnabled is true and otlpEndpoint is non-empty.
+telemetry:
+  # -- OTLP HTTP collector endpoint shared by Science Platform telemetry exporters. Required when telemetry.skahaEnabled is true.
+  otlpEndpoint: ""
+  # -- Export interval in seconds for Skaha Java-agent metrics.
+  exportIntervalSeconds: 60
+  # -- Enable the OpenTelemetry Java agent on the Skaha Tomcat container. Requires telemetry.otlpEndpoint.
+  skahaEnabled: false
+  metrics:
+    # -- OpenTelemetry service.name for the Skaha Tomcat workload.
+    skahaServiceName: canfar-skaha
+
 # Optional science-platform Metrics API in the same release as Skaha (see README).
 metricsBackend:
   # -- When true, install Kueue-read ClusterRole/Binding first (Helm kind order), then Metrics Service and Deployment. Applies fail if cluster RBAC cannot be created (for example forbidden).

--- a/skaha/Dockerfile
+++ b/skaha/Dockerfile
@@ -9,19 +9,7 @@ COPY . /src
 WORKDIR /src/skaha
 RUN ./gradlew clean spotlessCheck build --no-daemon
 
-FROM base AS otel-javaagent
-ARG OTEL_JAVA_AGENT_VERSION=2.29.0
-ARG OTEL_JAVA_AGENT_SHA256=546531ca690a8603d2923b6db26bbda35c6409327b1e610430ae33c2f8f68050
-
-RUN set -eux \
-    && apk add --no-cache curl \
-    && mkdir -p /opt/opentelemetry-javaagent \
-    && curl --fail --location --show-error --silent \
-        --output /tmp/opentelemetry-javaagent.jar \
-        "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v${OTEL_JAVA_AGENT_VERSION}/opentelemetry-javaagent.jar" \
-    && echo "${OTEL_JAVA_AGENT_SHA256}  /tmp/opentelemetry-javaagent.jar" | sha256sum --check --status \
-    && mv /tmp/opentelemetry-javaagent.jar /opt/opentelemetry-javaagent/opentelemetry-javaagent.jar \
-    && chmod 0444 /opt/opentelemetry-javaagent/opentelemetry-javaagent.jar
+FROM ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java:2.29.0@sha256:3571c114fa43ca9ce1997ad50e695e601e1dfbfd3f8afde24f2ad00810a89ad2 AS otel-javaagent
 
 FROM images.opencadc.org/library/cadc-tomcat:1 AS production
 
@@ -38,5 +26,5 @@ RUN set -eux \
     # Clean up dnf cache and other unneeded files to reduce image size
     && dnf clean all
 
-COPY --from=otel-javaagent /opt/opentelemetry-javaagent/opentelemetry-javaagent.jar /opt/opentelemetry-javaagent/opentelemetry-javaagent.jar
+COPY --from=otel-javaagent /javaagent.jar /opt/opentelemetry-javaagent/opentelemetry-javaagent.jar
 COPY --from=builder /src/skaha/build/libs/skaha.war /usr/share/tomcat/webapps/

--- a/skaha/Dockerfile
+++ b/skaha/Dockerfile
@@ -9,6 +9,20 @@ COPY . /src
 WORKDIR /src/skaha
 RUN ./gradlew clean spotlessCheck build --no-daemon
 
+FROM base AS otel-javaagent
+ARG OTEL_JAVA_AGENT_VERSION=2.29.0
+ARG OTEL_JAVA_AGENT_SHA256=546531ca690a8603d2923b6db26bbda35c6409327b1e610430ae33c2f8f68050
+
+RUN set -eux \
+    && apk add --no-cache curl \
+    && mkdir -p /opt/opentelemetry-javaagent \
+    && curl --fail --location --show-error --silent \
+        --output /tmp/opentelemetry-javaagent.jar \
+        "https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/download/v${OTEL_JAVA_AGENT_VERSION}/opentelemetry-javaagent.jar" \
+    && echo "${OTEL_JAVA_AGENT_SHA256}  /tmp/opentelemetry-javaagent.jar" | sha256sum --check --status \
+    && mv /tmp/opentelemetry-javaagent.jar /opt/opentelemetry-javaagent/opentelemetry-javaagent.jar \
+    && chmod 0444 /opt/opentelemetry-javaagent/opentelemetry-javaagent.jar
+
 FROM images.opencadc.org/library/cadc-tomcat:1 AS production
 
 RUN set -eux \
@@ -24,4 +38,5 @@ RUN set -eux \
     # Clean up dnf cache and other unneeded files to reduce image size
     && dnf clean all
 
+COPY --from=otel-javaagent /opt/opentelemetry-javaagent/opentelemetry-javaagent.jar /opt/opentelemetry-javaagent/opentelemetry-javaagent.jar
 COPY --from=builder /src/skaha/build/libs/skaha.war /usr/share/tomcat/webapps/


### PR DESCRIPTION
## Summary

- bundle OpenTelemetry Java agent 2.29.0 in the Skaha image by copying `/javaagent.jar` from the official `ghcr.io/open-telemetry/opentelemetry-operator/autoinstrumentation-java` image pinned by digest
- expose Helm telemetry values as `telemetry.controller`, reserved `telemetry.metrics`, and `telemetry.otlp.destination/interval`; controller OTEL only renders when enabled with a destination
- emit Skaha controller metrics with fixed `OTEL_SERVICE_NAME=skaha-controller`; reserve the future metrics backend name as `skaha-metrics` and fail fast if `telemetry.metrics=true` in this chart version
- document the new Helm values with helm-docs and keep the Helm render contract test wired into PR CI

## Scope

CADC-15901 only. CADC-14991 pagination/OOM work is intentionally not included here and is handled externally through Metrics provider work.

## Validation

- `helm/tests/test-skaha-otel-render.sh`
- `helm-docs --chart-search-root helm --template-files README.md.gotmpl`
- `helm lint helm --set deployment.skaha.sessions.userStorage.nodeURIPrefix=vos://storage.example.org~cavern`
- `docker build -f skaha/Dockerfile -t skaha-otel:test .`
- `docker run --rm --entrypoint sha256sum skaha-otel:test /opt/opentelemetry-javaagent/opentelemetry-javaagent.jar`
- `pre-commit run --all-files`

Jira: https://herzberg.atlassian.net/browse/CADC-15901